### PR TITLE
Add support for GraphQL API, starting with createEtchPacket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 package-lock.json
 example/script/*.pdf
 example/script/*.json
+
+scratch/

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Our API has request rate limits in place. This API client handles `429 Too Many 
 
 See the [Anvil API docs](https://useanvil.com/api/fill-pdf) for more information on the specifics of the rate limits.
 
-### API Documentation
+## API Documentation
 
 Our general API Documentation can be found [here](https://www.useanvil.com/api/). It's the best resource for up-to-date information about our API and its capabilities.
 

--- a/README.md
+++ b/README.md
@@ -114,23 +114,11 @@ Creates an Etch Packet and optionally sends it to the first signer. See the [API
 
 ### Class Methods
 
-##### prepareGraphQLStream(pathOrStream[, options])
-A nice helper to prepare a Stream-backed file upload for use with our GraphQL API.
-* `pathOrStream` (Stream | String) - Either an existing `Stream` or a string representing a fully resolved path to a file to be read into a new `Stream`.
+##### prepareGraphQLFile(pathOrStreamOrBuffer[, options])
+A nice helper to prepare a Stream-backed or Buffer-backed file upload for use with our GraphQL API.
+* `pathOrStream` (String | Stream | Buffer) - An existing `Stream` OR an existing `Buffer` OR a string representing a fully resolved path to a file to be read into a new `Stream`.
 * `options` (Object) - [UploadOptions](#uploadoptions) for the resulting object.
 * Returns an `Object` that is properly formatted to be coerced by the client for use against our GraphQL API wherever an `Upload` type is required.
-
-##### prepareGraphQLBuffer(pathOrBuffer[, options])
-A nice helper to prepare a Buffer-backed file upload for use with our GraphQL API.
-* `pathOrBuffer` (Buffer | String) - Either an existing `Buffer` or a string representing a fully resolved path to a file to be read into a new `Buffer`.
-* `options` (Object) - [UploadOptions](#uploadoptions) for the resulting object.
-* Returns an `Object` that is properly formatted to be coerced by the client for use against our GraphQL API wherever an `Upload` type is required.
-
-##### prepareGraphQLBase64(data, options)
-A nice helper to prepare a Base64-encoded-string-backed upload for use with our GraphQL API.
-* `data` (String) - A `base64`-encoded string.
-* `options` (Object) - [UploadOptions](#uploadoptions) for the resulting object. Also supports a `bufferize (Boolean)` option - set to `true` to convert the data to a `Buffer` and then call `prepareGraphQLBuffer`.
-* Returns an `Object` that is properly formatted to be coerced by the client for use against our GraphQL API wherever a `Base64Upload` type is required.
 
 ### Types
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ fs.writeFileSync('output.pdf', data, { encoding: null })
 
 ## API
 
-### new Anvil(options)
+### Instance Methods
+
+##### new Anvil(options)
 
 Creates an Anvil client instance.
 
@@ -57,18 +59,9 @@ Creates an Anvil client instance.
 ```js
 const anvilClient = new Anvil({ apiKey: 'abc123' })
 ```
+<br />
 
-### Options
-
-Options for the Anvil Client. Defaults are shown after each option key.
-
-```js
-{
-  apiKey: <your_api_key> // Required. Your API key from your Anvil organization settings
-}
-```
-
-### Anvil::fillPDF(pdfTemplateID, payload[, options])
+##### fillPDF(pdfTemplateID, payload[, options])
 
 Fills a PDF with your JSON data.
 
@@ -115,15 +108,63 @@ const { statusCode, data } = await anvilClient.fillPDF(pdfTemplateID, payload, o
   * `errors` (Array of Objects) - Will be present if status >= 400. See Errors
     * `message` (String)
 
+##### createEtchPacket(variables[, responseQuery])
+
+Creates an Etch Packet and optionally sends it to the first signer. See the [API Documentation](#api-documentation) area for details. See [Examples](#examples) area for examples.
+
+### Class Methods
+
+##### prepareGraphQLStream(pathOrStream[, options])
+A nice helper to prepare a Stream-backed file upload for use with our GraphQL API.
+* `pathOrStream` (Stream | String) - Either an existing `Stream` or a string representing a fully resolved path to a file to be read into a new `Stream`.
+* `options` (Object) - [UploadOptions](#uploadoptions) for the resulting object.
+* Returns an `Object` that is properly formatted to be coerced by the client for use against our GraphQL API wherever an `Upload` type is required.
+
+##### prepareGraphQLBuffer(pathOrBuffer[, options])
+A nice helper to prepare a Buffer-backed file upload for use with our GraphQL API.
+* `pathOrBuffer` (Buffer | String) - Either an existing `Buffer` or a string representing a fully resolved path to a file to be read into a new `Buffer`.
+* `options` (Object) - [UploadOptions](#uploadoptions) for the resulting object.
+* Returns an `Object` that is properly formatted to be coerced by the client for use against our GraphQL API wherever an `Upload` type is required.
+
+##### prepareGraphQLBase64(data, options)
+A nice helper to prepare a Base64-encoded-string-backed upload for use with our GraphQL API.
+* `data` (String) - A `base64`-encoded string.
+* `options` (Object) - [UploadOptions](#uploadoptions) for the resulting object. Also supports a `bufferize (Boolean)` option - set to `true` to convert the data to a `Buffer` and then call `prepareGraphQLBuffer`.
+* Returns an `Object` that is properly formatted to be coerced by the client for use against our GraphQL API wherever a `Base64Upload` type is required.
+
+### Types
+
+##### Options
+
+Options for the Anvil Client. Defaults are shown after each option key.
+
+```js
+{
+  apiKey: <your_api_key> // Required. Your API key from your Anvil organization settings
+}
+```
+
+##### UploadOptions
+
+Options for the upload preparation class methods.
+```js
+{
+  filename: <filename>, // String
+  mimetype: <mimetype> // String
+}
+```
+
 ### Rate Limits
 
 Our API has request rate limits in place. This API client handles `429 Too Many Requests` errors by waiting until it can retry again, then retrying the request. The client attempts to avoid `429` errors by throttling requests after the number of requests within the specified time period has been reached.
 
 See the [Anvil API docs](https://useanvil.com/api/fill-pdf) for more information on the specifics of the rate limits.
 
-### More Info
+### API Documentation
 
-See the [PDF filling API docs](https://useanvil.com/api/fill-pdf) for more information.
+Our general API Documentation can be found [here](https://www.useanvil.com/api/). It's the best resource for up-to-date information about our API and its capabilities.
+
+See the [PDF filling API docs](https://useanvil.com/api/fill-pdf) for more information about the `fillPDF` method.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -108,9 +108,12 @@ const { statusCode, data } = await anvilClient.fillPDF(pdfTemplateID, payload, o
   * `errors` (Array of Objects) - Will be present if status >= 400. See Errors
     * `message` (String)
 
-##### createEtchPacket(variables[, responseQuery])
+##### createEtchPacket(options)
 
-Creates an Etch Packet and optionally sends it to the first signer. See the [API Documentation](#api-documentation) area for details. See [Examples](#examples) area for examples.
+Creates an Etch Packet and optionally sends it to the first signer.
+* `options` (Object) - An object with the following structure:
+  * `variables` (Object) - See the [API Documentation](#api-documentation) area for details. See [Examples](#examples) area for examples.
+  * `responseQuery` (String) - _optional_ A GraphQL Query compliant query to use for the data desired in the mutation response. Can be left out to use default.
 
 ### Class Methods
 

--- a/example/script/create-etch-packet.js
+++ b/example/script/create-etch-packet.js
@@ -1,4 +1,3 @@
-const fs = require('fs')
 const path = require('path')
 const Anvil = require('../../src/index')
 const argv = require('yargs')
@@ -15,12 +14,9 @@ async function main () {
 
   const client = new Anvil(clientOptions)
 
-  // Stream example. Can also use prepareGraphQLBuffer for Buffers
-  const streamFile = Anvil.prepareGraphQLStream(pathToFile)
-
-  // Base64 data example. Filename and mimetype are required with a Base64 upload.
-  const base64Data = fs.readFileSync(pathToFile, { encoding: 'base64' })
-  const base64File = Anvil.prepareGraphQLBase64(base64Data, { filename: fileName, mimetype: 'application/pdf' })
+  // Example where pathToFile will be used to create a new Stream. Can also
+  // pass an existing Stream or Buffer
+  const streamFile = Anvil.prepareGraphQLFile(pathToFile)
 
   const variables = {
     organizationEid: orgEid,
@@ -85,24 +81,6 @@ async function main () {
         ],
       },
       {
-        id: 'base64upload',
-        title: 'Important PDF 2',
-        base64File: base64File,
-        fields: [
-          {
-            aliasId: 'anotherSignatureField',
-            type: 'signature',
-            pageNum: 1,
-            rect: {
-              x: 203.88,
-              y: 171.66,
-              width: 33.94,
-              height: 27.60,
-            },
-          },
-        ],
-      },
-      {
         id: 'preExistingCastReference',
         castEid: castEid,
       },
@@ -127,11 +105,13 @@ async function main () {
   }`
 
   const { statusCode, data, errors } = await client.createEtchPacket({ variables, responseQuery })
-  console.log({
-    statusCode,
-    data,
-    errors,
-  })
+  console.log(
+    JSON.stringify({
+      statusCode,
+      data,
+      errors,
+    }),
+  )
 }
 
 main()

--- a/example/script/create-etch-packet.js
+++ b/example/script/create-etch-packet.js
@@ -87,24 +87,7 @@ async function main () {
     ],
   }
 
-  // Show this to the world?
-  const responseQuery = `{
-    id
-    eid
-    payload
-    etchTemplate {
-      id
-      eid
-      config
-      casts {
-        id
-        eid
-        config
-      }
-    }
-  }`
-
-  const { statusCode, data, errors } = await client.createEtchPacket({ variables, responseQuery })
+  const { statusCode, data, errors } = await client.createEtchPacket({ variables })
   console.log(
     JSON.stringify({
       statusCode,

--- a/example/script/create-etch-packet.js
+++ b/example/script/create-etch-packet.js
@@ -1,0 +1,149 @@
+const fs = require('fs')
+const path = require('path')
+const Anvil = require('../../src/index')
+const argv = require('yargs')
+  .usage('Usage: $0 apiKey orgEid castEid, fileName')
+  .option('user-agent', {
+    alias: 'a',
+    type: 'string',
+    description: 'Set the User-Agent on any requests made (default is "Anvil API Client")',
+  })
+  .demandCommand(4).argv
+
+const [apiKey, orgEid, castEid, fileName] = argv._
+const userAgent = argv['user-agent']
+
+const pathToFile = path.resolve(__dirname, fileName)
+
+async function main () {
+  const clientOptions = {
+    apiKey,
+  }
+  if (userAgent) {
+    clientOptions.userAgent = userAgent
+  }
+
+  const client = new Anvil(clientOptions)
+
+  const fileStream = await Anvil.addStream(pathToFile)
+  const base64File = fs.readFileSync(pathToFile, { encoding: 'base64' })
+  const variables = {
+    organizationEid: orgEid,
+    send: false,
+    isTest: true,
+    signers: [
+      {
+        id: 'signerOne',
+        name: 'Sally Signer',
+        email: 'sally@example.com',
+        fields: [
+          {
+            fileId: 'fileOne',
+            fieldId: 'aDateField',
+          },
+          {
+            fileId: 'fileOne',
+            fieldId: 'aSignatureField',
+          },
+        ],
+      },
+      {
+        id: 'signerTwo',
+        name: 'Scotty Signer',
+        email: 'scotty@example.com',
+        fields: [
+          {
+            fileId: 'base64upload',
+            fieldId: 'anotherSignatureField',
+          },
+        ],
+      },
+    ],
+    files: [
+      {
+        id: 'fileUpload',
+        title: 'Important PDF One',
+        file: fileStream,
+        fields: [
+          {
+            aliasId: 'aDateField',
+            type: 'signatureDate',
+            pageNum: 1,
+            rect: {
+              x: 203.88,
+              y: 171.66,
+              width: 33.94,
+              height: 27.60,
+            },
+          },
+          {
+            aliasId: 'aSignatureField',
+            type: 'signature',
+            pageNum: 1,
+            rect: {
+              x: 203.88,
+              y: 121.66,
+              width: 33.94,
+              height: 27.60,
+            },
+          },
+        ],
+      },
+      {
+        id: 'base64upload',
+        title: 'Important PDF 2',
+        base64File: {
+          filename: fileName,
+          mimetype: 'application/pdf',
+          data: base64File,
+        },
+        fields: [
+          {
+            aliasId: 'anotherSignatureField',
+            type: 'signature',
+            pageNum: 1,
+            rect: {
+              x: 203.88,
+              y: 171.66,
+              width: 33.94,
+              height: 27.60,
+            },
+          },
+        ],
+      },
+      {
+        id: 'preExistingCastReference',
+        castEid: castEid,
+      },
+    ],
+  }
+
+  const responseQuery = `{
+    id
+    eid
+    payload
+    etchTemplate {
+      id
+      eid
+      config
+      casts {
+        id
+        eid
+        config
+      }
+    }
+  }`
+
+  const { statusCode, data, errors } = await client.createEtchPacket({ variables, responseQuery })
+
+  console.log(statusCode, JSON.stringify(errors || data, null, 2))
+}
+
+main()
+  .then(() => {
+    process.exit(0)
+  })
+  .catch((err) => {
+    console.log(err.stack || err.message)
+    process.exit(1)
+  })

--- a/example/script/create-etch-packet.js
+++ b/example/script/create-etch-packet.js
@@ -22,6 +22,7 @@ async function main () {
     organizationEid: orgEid,
     send: false,
     isTest: true,
+    signatureEmailSubject: 'Test Create Packet',
     signers: [
       {
         id: 'signerOne',
@@ -29,11 +30,11 @@ async function main () {
         email: 'sally@example.com',
         fields: [
           {
-            fileId: 'fileOne',
+            fileId: 'fileUpload',
             fieldId: 'aDateField',
           },
           {
-            fileId: 'fileOne',
+            fileId: 'fileUpload',
             fieldId: 'aSignatureField',
           },
         ],
@@ -44,12 +45,44 @@ async function main () {
         email: 'scotty@example.com',
         fields: [
           {
-            fileId: 'base64upload',
+            fileId: 'fileUpload',
             fieldId: 'anotherSignatureField',
+          },
+          {
+            fileId: 'preExistingCastReference',
+            fieldId: 'signature1',
+          },
+          {
+            fileId: 'preExistingCastReference',
+            fieldId: 'signatureDate1',
           },
         ],
       },
     ],
+    fillPayload: {
+      payloads: {
+        fileUpload: {
+          textColor: '#CC0000',
+          data: {
+            myShortText: 'Something Filled',
+          },
+        },
+        preExistingCastReference: {
+          textColor: '#00CC00',
+          data: {
+            name: {
+              firstName: 'Robin',
+              lastName: 'Smith',
+            },
+            dateOfBirth: '2020-09-01',
+            socialSecurityNumber: '456454567',
+            primaryPhone: {
+              num: '5554443333',
+            },
+          },
+        },
+      },
+    },
     files: [
       {
         id: 'fileUpload',
@@ -57,25 +90,50 @@ async function main () {
         file: streamFile,
         fields: [
           {
-            aliasId: 'aDateField',
-            type: 'signatureDate',
-            pageNum: 1,
+            id: 'myShortText',
+            type: 'shortText',
+            pageNum: 0,
             rect: {
-              x: 203.88,
-              y: 171.66,
-              width: 33.94,
-              height: 27.60,
+              x: 20,
+              y: 100,
+              width: 100,
+              height: 30,
             },
           },
           {
-            aliasId: 'aSignatureField',
+            id: 'aDateField',
+            type: 'signatureDate',
+            pageNum: 1,
+            name: 'Some Date',
+            rect: {
+              x: 200,
+              y: 170,
+              width: 100,
+              height: 30,
+            },
+          },
+          {
+            id: 'aSignatureField',
             type: 'signature',
+            name: 'Some Sig',
             pageNum: 1,
             rect: {
-              x: 203.88,
-              y: 121.66,
-              width: 33.94,
-              height: 27.60,
+              x: 200,
+              y: 120,
+              width: 100,
+              height: 30,
+            },
+          },
+          {
+            id: 'anotherSignatureField',
+            type: 'signature',
+            name: 'Another Sig',
+            pageNum: 1,
+            rect: {
+              x: 200,
+              y: 400,
+              width: 100,
+              height: 30,
             },
           },
         ],

--- a/example/script/create-etch-packet.js
+++ b/example/script/create-etch-packet.js
@@ -15,12 +15,12 @@ async function main () {
 
   const client = new Anvil(clientOptions)
 
-  // Stream example. Can also use prepareBuffer for Buffers
-  const streamFile = Anvil.prepareStream(pathToFile)
+  // Stream example. Can also use prepareGraphQLBuffer for Buffers
+  const streamFile = Anvil.prepareGraphQLStream(pathToFile)
 
   // Base64 data example. Filename and mimetype are required with a Base64 upload.
   const base64Data = fs.readFileSync(pathToFile, { encoding: 'base64' })
-  const base64File = Anvil.prepareBase64(base64Data, { filename: fileName, mimetype: 'application/pdf' })
+  const base64File = Anvil.prepareGraphQLBase64(base64Data, { filename: fileName, mimetype: 'application/pdf' })
 
   const variables = {
     organizationEid: orgEid,

--- a/package.json
+++ b/package.json
@@ -49,7 +49,10 @@
     "yargs": "^15.1.0"
   },
   "dependencies": {
+    "extract-files": "^6",
+    "form-data": "^3.0.0",
     "limiter": "^1.1.5",
+    "mime-types": "^2.1.27",
     "node-fetch": "^2.6.0"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "yargs": "^15.1.0"
   },
   "dependencies": {
+    "abort-controller": "^3.0.0",
     "extract-files": "^6",
     "form-data": "^3.0.0",
     "limiter": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Anvil API Client",
   "main": "src/index.js",
   "scripts": {
-    "test": "mocha --require test/environment.js 'test/**/*.test.js'",
+    "test": "mocha --config ./test/mocha.js",
     "test:watch": "nodemon --signal SIGINT --watch test --watch src -x 'yarn test'",
     "version": "auto-changelog -p --template keepachangelog && git add CHANGELOG.md"
   },
@@ -30,6 +30,7 @@
   "devDependencies": {
     "auto-changelog": "^1.16.2",
     "babel-eslint": "^10.0.3",
+    "bdd-lazy-var": "^2.5.4",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "extract-files": "^6",
     "form-data": "^3.0.0",
     "limiter": "^1.1.5",
+    "lodash.get": "^4.4.2",
     "mime-types": "^2.1.27",
     "node-fetch": "^2.6.0"
   },

--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -1,0 +1,5 @@
+const mutations = require('./mutations')
+
+module.exports = {
+  mutations,
+}

--- a/src/graphql/mutations/createEtchPacket.js
+++ b/src/graphql/mutations/createEtchPacket.js
@@ -1,0 +1,44 @@
+
+const defaultResponseQuery = `{
+  id
+  eid
+  etchTemplate {
+    id
+    eid
+    config
+    casts {
+      id
+      eid
+      config
+    }
+  }
+}`
+
+module.exports = {
+  getMutation: (responseQuery = defaultResponseQuery) => `
+    mutation CreateEtchPacket (
+      $name: String,
+      $organizationEid: String!,
+      $files: [EtchFile!],
+      $send: Boolean,
+      $isTest: Boolean,
+      $signatureEmailSubject: String,
+      $signatureEmailBody: String,
+      $signaturePageOptions: JSON,
+      $signers: [JSON!],
+      $fillPayload: JSON,
+    ) {
+      createEtchPacket (
+        name: $name,
+        organizationEid: $organizationEid,
+        files: $files,
+        send: $send,
+        isTest: $isTest,
+        signatureEmailSubject: $signatureEmailSubject,
+        signatureEmailBody: $signatureEmailBody,
+        signaturePageOptions: $signaturePageOptions,
+        signers: $signers,
+        fillPayload: $fillPayload
+      ) ${responseQuery}
+    }`,
+}

--- a/src/graphql/mutations/createEtchPacket.js
+++ b/src/graphql/mutations/createEtchPacket.js
@@ -2,14 +2,16 @@
 const defaultResponseQuery = `{
   id
   eid
-  etchTemplate {
+  name
+  documentGroup {
     id
     eid
-    config
-    casts {
+    files
+    signers {
       id
       eid
-      config
+      name
+      email
     }
   }
 }`

--- a/src/graphql/mutations/index.js
+++ b/src/graphql/mutations/index.js
@@ -1,0 +1,11 @@
+const fs = require('fs')
+
+const IGNORE_FILES = ['index.js']
+
+module.exports = fs.readdirSync(__dirname)
+  .filter((fileName) => (fileName.endsWith('.js') && !fileName.startsWith('.') && !IGNORE_FILES.includes(fileName)))
+  .reduce((acc, fileName) => {
+    const mutationName = fileName.slice(0, fileName.length - 3)
+    acc[mutationName] = require(`./${mutationName}`)
+    return acc
+  }, {})

--- a/src/index.js
+++ b/src/index.js
@@ -132,7 +132,7 @@ class Anvil {
       data,
       errors,
     } = await this._wrapRequest(
-      async () => this._request(url, options),
+      () => this._request(url, options),
       clientOptions,
     )
 
@@ -215,9 +215,9 @@ class Anvil {
     return fetch(url, opts)
   }
 
-  async _wrapRequest (preparedRequest, clientOptions = {}) {
+  async _wrapRequest (retryableRequestFn, clientOptions = {}) {
     return this._throttle(async (retry) => {
-      const response = await preparedRequest()
+      const response = await retryableRequestFn()
       const statusCode = response.status
 
       if (statusCode >= 300) {

--- a/src/index.js
+++ b/src/index.js
@@ -62,23 +62,23 @@ class Anvil {
     this.limiter = new RateLimiter(this.requestLimit, this.requestLimitMS, true)
   }
 
-  static prepareStream (pathOrStream, options) {
+  static prepareGraphQLStream (pathOrStream, options) {
     if (typeof pathOrStream === 'string') {
       pathOrStream = fs.createReadStream(pathOrStream)
     }
 
-    return this._prepareStreamOrBuffer(pathOrStream, options)
+    return this._prepareGraphQLStreamOrBuffer(pathOrStream, options)
   }
 
-  static prepareBuffer (pathOrBuffer, options) {
+  static prepareGraphQLBuffer (pathOrBuffer, options) {
     if (typeof pathOrBuffer === 'string') {
       pathOrBuffer = fs.readFileSync(pathOrBuffer)
     }
 
-    return this._prepareStreamOrBuffer(pathOrBuffer, options)
+    return this._prepareGraphQLStreamOrBuffer(pathOrBuffer, options)
   }
 
-  static prepareBase64 (data, options = {}) {
+  static prepareGraphQLBase64 (data, options = {}) {
     const { filename, mimetype } = options
     if (!filename) {
       throw new Error('options.filename must be provided for Base64 upload')
@@ -92,7 +92,7 @@ class Anvil {
       return this.addBuffer(buffer, options)
     }
 
-    return this._prepareBase64(data, options)
+    return this._prepareGraphQLBase64(data, options)
   }
 
   fillPDF (pdfTemplateID, payload, clientOptions = {}) {
@@ -337,7 +337,7 @@ class Anvil {
     })
   }
 
-  static _prepareStreamOrBuffer (streamOrBuffer, options) {
+  static _prepareGraphQLStreamOrBuffer (streamOrBuffer, options) {
     const filename = this._getFilename(streamOrBuffer, options)
     const mimetype = this._getMimetype(streamOrBuffer, options)
     return {
@@ -347,7 +347,7 @@ class Anvil {
     }
   }
 
-  static _prepareBase64 (data, options = {}) {
+  static _prepareGraphQLBase64 (data, options = {}) {
     const { filename, mimetype } = options
     if (!filename) {
       throw new Error('options.filename must be provided for Base64 upload')

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,47 @@ const defaultOptions = {
 
 const failBufferMS = 50
 
+const Mutation = `
+  mutation CreateEtchPacket (
+    $name: String,
+    $organizationEid: String!,
+    $files: [EtchFile!],
+    $send: Boolean,
+    $isTest: Boolean,
+    $signatureEmailSubject: String,
+    $signatureEmailBody: String,
+    $signaturePageOptions: JSON,
+    $signers: [JSON!],
+    $fillPayload: JSON,
+  ) {
+    createEtchPacket (
+      name: $name,
+      organizationEid: $organizationEid,
+      files: $files,
+      send: $send,
+      isTest: $isTest,
+      signatureEmailSubject: $signatureEmailSubject,
+      signatureEmailBody: $signatureEmailBody,
+      signaturePageOptions: $signaturePageOptions,
+      signers: $signers,
+      fillPayload: $fillPayload
+    ) {
+      id
+      eid
+      etchTemplate {
+        id
+        eid
+        config
+        casts {
+          id
+          eid
+          config
+        }
+      }
+    }
+  }
+`
+
 class Anvil {
   // {
   //   apiKey: <yourAPIKey>,
@@ -62,6 +103,24 @@ class Anvil {
     )
   }
 
+  getCurrentUser () {
+    const query = `
+      query {
+        currentUser {
+          id
+          email
+        }
+      }
+    `
+    const variables = {}
+
+    return this.requestGraphQL({ query, variables })
+  }
+
+  createEtchPacket () {
+
+  }
+
   // Private
 
   async requestREST (url, options, clientOptions = {}) {
@@ -99,6 +158,32 @@ class Anvil {
 
       return { statusCode, data }
     })
+  }
+
+  async requestGraphQL ({ query, variables = {} }) {
+    const options = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: this.options.cookie,
+      },
+      body: JSON.stringify({
+        query,
+        variables,
+      }),
+    }
+
+    const response = await this.request('/graphql', options)
+
+    console.log({ response })
+
+    const data = await response.json()
+
+    console.log({ data })
+    return {
+      statusCode: response.status,
+      data,
+    }
   }
 
   throttle (fn) {

--- a/src/index.js
+++ b/src/index.js
@@ -94,8 +94,6 @@ class Anvil {
     )
   }
 
-  // QUESTION: maybe we want to keeep responseQuery to ourselves while we figure out how we want it to
-  // feel to the Users?
   createEtchPacket ({ variables, responseQuery }) {
     return this.requestGraphQL(
       {

--- a/src/index.js
+++ b/src/index.js
@@ -4,10 +4,18 @@ const path = require('path')
 const fetch = require('node-fetch')
 const FormData = require('form-data')
 const mime = require('mime-types')
-const extractFiles = require('extract-files').extractFiles
-const RateLimiter = require('limiter').RateLimiter
+const { extractFiles } = require('extract-files')
+const { RateLimiter } = require('limiter')
 
 const { version, description } = require('../package.json')
+
+const {
+  mutations: {
+    createEtchPacket: {
+      getMutation: getCreateEtchPacketMutation,
+    },
+  },
+} = require('./graphql')
 
 const DATA_TYPE_STREAM = 'stream'
 const DATA_TYPE_BUFFER = 'buffer'
@@ -19,47 +27,6 @@ const defaultOptions = {
 }
 
 const failBufferMS = 50
-
-const Mutation = `
-  mutation CreateEtchPacket (
-    $name: String,
-    $organizationEid: String!,
-    $files: [EtchFile!],
-    $send: Boolean,
-    $isTest: Boolean,
-    $signatureEmailSubject: String,
-    $signatureEmailBody: String,
-    $signaturePageOptions: JSON,
-    $signers: [JSON!],
-    $fillPayload: JSON,
-  ) {
-    createEtchPacket (
-      name: $name,
-      organizationEid: $organizationEid,
-      files: $files,
-      send: $send,
-      isTest: $isTest,
-      signatureEmailSubject: $signatureEmailSubject,
-      signatureEmailBody: $signatureEmailBody,
-      signaturePageOptions: $signaturePageOptions,
-      signers: $signers,
-      fillPayload: $fillPayload
-    ) {
-      id
-      eid
-      etchTemplate {
-        id
-        eid
-        config
-        casts {
-          id
-          eid
-          config
-        }
-      }
-    }
-  }
-`
 
 class Anvil {
   // {
@@ -85,18 +52,271 @@ class Anvil {
     this.limiter = new RateLimiter(this.requestLimit, this.requestLimitMS, true)
   }
 
-  static prepareFile (path) {
-    const readStream = fs.createReadStream(path)
-    const fileName = this.getFilename(readStream)
-    const mimeType = this.getMimetype(readStream)
+  static addStream (pathOrStream) {
+    if (typeof pathOrStream === 'string') {
+      pathOrStream = fs.createReadStream(pathOrStream)
+    }
+    return this._prepareFile(pathOrStream)
+  }
+
+  static addBuffer (pathOrBuffer) {
+    if (typeof pathOrBuffer === 'string') {
+      pathOrBuffer = fs.readFileSync(pathOrBuffer)
+    }
+    return this._prepareFile(pathOrBuffer)
+  }
+
+  fillPDF (pdfTemplateID, payload, clientOptions = {}) {
+    const supportedDataTypes = [DATA_TYPE_STREAM, DATA_TYPE_BUFFER]
+    const { dataType = DATA_TYPE_BUFFER } = clientOptions
+    if (dataType && !supportedDataTypes.includes(dataType)) {
+      throw new Error(`dataType must be one of: ${supportedDataTypes.join('|')}`)
+    }
+
+    return this._requestREST(
+      `/api/v1/fill/${pdfTemplateID}.pdf`,
+      {
+        method: 'POST',
+        body: JSON.stringify(payload),
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: this.authHeader,
+        },
+      },
+      {
+        ...clientOptions,
+        dataType,
+      },
+    )
+  }
+
+  // Just here for now to highlight authentication questions/concerns
+  getCurrentUser () {
+    const query = `
+      query {
+        currentUser {
+          id
+          email
+        }
+      }
+    `
+    return this._requestGraphQL({ query })
+  }
+
+  // QUESTION: maybe we want to keeep responseQuery to ourselves while we figure out how we want it to
+  // feel to the Users?
+  createEtchPacket ({ variables, responseQuery }) {
+    return this._requestGraphQL(
+      {
+        query: getCreateEtchPacketMutation(responseQuery),
+        variables,
+      },
+      { dataType: 'json' },
+    )
+  }
+
+  // ******************************************************************************
+  //     ___      _           __
+  //    / _ \____(_)  _____ _/ /____
+  //   / ___/ __/ / |/ / _ `/ __/ -_)
+  //  /_/  /_/ /_/|___/\_,_/\__/\__/
+  //
+  // ALL THE BELOW CODE IS CONSIDERED PRIVATE, AND THE API OR INTERNALS MAY CHANGE AT ANY TIME
+  // USERS OF THIS MODULE SHOULD NOT USE ANY OF THESE METHODS DIRECTLY
+  // ******************************************************************************
+
+  async _requestREST (url, options, clientOptions) {
+    const {
+      response,
+      statusCode,
+      data,
+      errors,
+    } = await this._wrapRequest(
+      async () => this._request(url, options),
+      clientOptions,
+    )
+
     return {
-      name: fileName,
-      mimetype: mimeType,
-      file: readStream,
+      response,
+      statusCode,
+      data,
+      errors,
     }
   }
 
-  static getFilename (thing, options = {}) {
+  async _requestGraphQL ({ query, variables = {} }, clientOptions) {
+    // Some helpful resources on how this came to be:
+    // https://github.com/jaydenseric/graphql-upload/issues/125#issuecomment-440853538
+    // https://zach.codes/building-a-file-upload-hook/
+    // https://github.com/jaydenseric/graphql-react/blob/1b1234de5de46b7a0029903a1446dcc061f37d09/src/universal/graphqlFetchOptions.mjs
+    // https://www.npmjs.com/package/extract-files
+
+    const options = {
+      method: 'POST',
+      headers: {
+        // FIXME: How does /graphql auth work?
+        Cookie: this.options.cookie,
+      },
+    }
+
+    const operation = { query, variables }
+
+    const {
+      clone: augmentedOperation,
+      files: filesMap,
+    } = extractFiles(operation, '', isExtractableFile)
+
+    const operationJSON = JSON.stringify(augmentedOperation)
+
+    if (filesMap.size) {
+      const form = new FormData()
+
+      form.append('operations', operationJSON)
+
+      const map = {}
+      let i = 0
+      filesMap.forEach(paths => {
+        map[++i] = paths
+      })
+      form.append('map', JSON.stringify(map))
+
+      i = 0
+      filesMap.forEach((paths, file) => {
+        form.append(`${++i}`, file)
+      })
+
+      options.body = form
+    } else {
+      options.headers['Content-Type'] = 'application/json'
+      options.body = operationJSON
+    }
+
+    const {
+      statusCode,
+      data,
+      errors,
+    } = await this._wrapRequest(
+      () => this._request('/graphql', options),
+      clientOptions,
+    )
+
+    return {
+      statusCode,
+      data,
+      errors,
+    }
+  }
+
+  _request (url, options) {
+    if (!url.startsWith(this.options.baseURL)) {
+      url = this._url(url)
+    }
+    const opts = this._addDefaultHeaders(options)
+    return fetch(url, opts)
+  }
+
+  async _wrapRequest (preparedRequest, clientOptions = {}) {
+    return this._throttle(async (retry) => {
+      const response = await preparedRequest()
+      const statusCode = response.status
+
+      if (statusCode >= 300) {
+        if (statusCode === 429) {
+          return retry(getRetryMS(response.headers.get('retry-after')))
+        }
+
+        const json = await response.json()
+        const errors = json.errors || (json.message && [json])
+
+        return errors ? { statusCode, errors } : { statusCode, ...json }
+      }
+
+      const { dataType } = clientOptions
+      let data
+
+      switch (dataType) {
+        case DATA_TYPE_STREAM:
+          data = response.body
+          break
+        case DATA_TYPE_BUFFER:
+          data = await response.buffer()
+          break
+        case DATA_TYPE_JSON:
+          data = await response.json()
+          break
+        default:
+          console.warn('Using default response dataType of "json". Please specifiy a dataType.')
+          data = await response.json()
+          break
+      }
+
+      return {
+        response,
+        data,
+        statusCode,
+      }
+    })
+  }
+
+  _url (path) {
+    return this.options.baseURL + path
+  }
+
+  _addHeaders ({ options: existingOptions, headers: newHeaders }) {
+    const { headers: existingHeaders = {} } = existingOptions
+    return {
+      ...existingOptions,
+      headers: {
+        ...existingHeaders,
+        ...newHeaders,
+      },
+    }
+  }
+
+  _addDefaultHeaders (options) {
+    const { userAgent } = this.options
+    return this._addHeaders({
+      options,
+      headers: {
+        'User-Agent': userAgent,
+      },
+    })
+  }
+
+  _throttle (fn) {
+    return new Promise((resolve, reject) => {
+      this.limiter.removeTokens(1, async (err, remainingRequests) => {
+        if (err) reject(err)
+        if (remainingRequests < 1) {
+          await sleep(this.requestLimitMS + failBufferMS)
+        }
+        const retry = async (ms) => {
+          await sleep(ms)
+          return this._throttle(fn)
+        }
+        try {
+          resolve(await fn(retry))
+        } catch (e) {
+          reject(e)
+        }
+      })
+    })
+  }
+
+  static _prepareFile (streamOrBuffer) {
+    const fileName = this._getFilename(streamOrBuffer)
+    const mimeType = this._getMimetype(streamOrBuffer)
+    return {
+      name: fileName,
+      mimetype: mimeType,
+      file: streamOrBuffer,
+    }
+  }
+
+  static _getFilename (thing, options = {}) {
+    // Very heavily influenced by:
+    // https://github.com/form-data/form-data/blob/55d90ce4a4c22b0ea0647991d85cb946dfb7395b/lib/form_data.js#L217
+
     if (typeof options.filepath === 'string') {
       // custom filepath for relative paths
       return path.normalize(options.filepath).replace(/\\/g, '/')
@@ -111,7 +331,10 @@ class Anvil {
     }
   }
 
-  static getMimetype (thing, options = {}) {
+  static _getMimetype (thing, options = {}) {
+    // Very heavily influenced by:
+    // https://github.com/form-data/form-data/blob/55d90ce4a4c22b0ea0647991d85cb946dfb7395b/lib/form_data.js#L243
+
     // use custom content-type above all
     if (typeof options.mimeType === 'string') {
       return options.mimeType
@@ -142,233 +365,11 @@ class Anvil {
       return 'application/octet-stream'
     }
   }
+}
 
-  fillPDF (pdfTemplateID, payload, clientOptions = {}) {
-    const supportedDataTypes = [DATA_TYPE_STREAM, DATA_TYPE_BUFFER]
-    const { dataType = DATA_TYPE_BUFFER } = clientOptions
-    if (dataType && !supportedDataTypes.includes(dataType)) {
-      throw new Error(`dataType must be one of: ${supportedDataTypes.join('|')}`)
-    }
-
-    return this.requestREST(
-      `/api/v1/fill/${pdfTemplateID}.pdf`,
-      {
-        method: 'POST',
-        body: JSON.stringify(payload),
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: this.authHeader,
-        },
-      },
-      {
-        ...clientOptions,
-        dataType,
-      },
-    )
-  }
-
-  getCurrentUser () {
-    const query = `
-      query {
-        currentUser {
-          id
-          email
-        }
-      }
-    `
-    const variables = {}
-
-    return this.requestGraphQL({ query, variables })
-  }
-
-  createEtchPacket ({ variables }) {
-    return this.requestGraphQL({ query: Mutation, variables }, { dataType: 'json' })
-  }
-
-  // Private
-
-  async requestREST (url, options, clientOptions = {}) {
-    return this.throttle(async (retry) => {
-      const response = await this.request(url, options)
-      const statusCode = response.status
-
-      if (statusCode === 429) {
-        return retry(getRetryMS(response.headers.get('retry-after')))
-      }
-
-      if (statusCode >= 300) {
-        const json = await response.json()
-        const errors = json.errors || (json.message && [json])
-
-        return errors ? { statusCode, errors } : { statusCode, ...json }
-      }
-
-      const { dataType } = clientOptions
-      let data
-      switch (dataType) {
-        case DATA_TYPE_JSON:
-          data = await response.json()
-          break
-        case DATA_TYPE_STREAM:
-          data = response.body
-          break
-        case DATA_TYPE_BUFFER:
-          data = await response.buffer()
-          break
-        default:
-          data = await response.buffer()
-          break
-      }
-
-      return { statusCode, data }
-    })
-  }
-
-  async requestGraphQL ({ query, variables = {} }, clientOptions) {
-    const options = {
-      method: 'POST',
-      headers: {
-        // 'Content-Type': 'application/json',
-        Cookie: this.options.cookie,
-      },
-      // body: JSON.stringify({
-      //   query,
-      //   variables,
-      // }),
-    }
-
-    // const operation = {
-    //   query: Mutation,
-    //   variables,
-    // }
-
-    const { clone: augmentedOperation, files: filesMap } = extractFiles({ query, variables }, '', (value) => {
-      return value instanceof fs.ReadStream || value instanceof Buffer
-    })
-
-    const operationJSON = JSON.stringify(augmentedOperation)
-
-    // const options = {
-    //   url: '/graphql',
-    //   method: 'POST',
-    //   headers: {
-    //     Accept: 'application/json',
-    //   },
-    // }
-
-    if (filesMap.size) {
-      const form = new FormData()
-
-      form.append('operations', operationJSON)
-
-      const map = {}
-      let i = 0
-      filesMap.forEach(paths => {
-        map[++i] = paths
-      })
-      form.append('map', JSON.stringify(map))
-
-      i = 0
-      filesMap.forEach((paths, file) => {
-        form.append(`${++i}`, file)
-      })
-
-      console.log('map:', JSON.stringify(map))
-      console.log('filesMap:', JSON.stringify(filesMap))
-
-      console.log(JSON.stringify(form))
-      // console.log(form.getBuffer())
-      // console.log(form.toString())
-      // process.exit()
-
-      options.body = form
-    } else {
-      options.headers['Content-Type'] = 'application/json'
-      options.body = operationJSON
-    }
-
-    const response = await this.request('/graphql', options)
-
-    console.log({ response })
-
-    const statusCode = response.status
-
-    const { dataType } = clientOptions
-    let data
-    switch (dataType) {
-      case DATA_TYPE_JSON:
-        data = await response.json()
-        break
-      case DATA_TYPE_STREAM:
-        data = response.body
-        break
-      case DATA_TYPE_BUFFER:
-        data = await response.buffer()
-        break
-      default:
-        data = await response.buffer()
-        break
-    }
-
-    // console.log({ data })
-    return {
-      statusCode,
-      data,
-    }
-  }
-
-  throttle (fn) {
-    return new Promise((resolve, reject) => {
-      this.limiter.removeTokens(1, async (err, remainingRequests) => {
-        if (err) reject(err)
-        if (remainingRequests < 1) {
-          await sleep(this.requestLimitMS + failBufferMS)
-        }
-        const retry = async (ms) => {
-          await sleep(ms)
-          return this.throttle(fn)
-        }
-        try {
-          resolve(await fn(retry))
-        } catch (e) {
-          reject(e)
-        }
-      })
-    })
-  }
-
-  request (url, options) {
-    if (!url.startsWith(this.options.baseURL)) {
-      url = this.url(url)
-    }
-    const opts = this.addDefaultHeaders(options)
-    return fetch(url, opts)
-  }
-
-  url (path) {
-    return this.options.baseURL + path
-  }
-
-  addHeaders ({ options: existingOptions, headers: newHeaders }) {
-    const { headers: existingHeaders = {} } = existingOptions
-    return {
-      ...existingOptions,
-      headers: {
-        ...existingHeaders,
-        ...newHeaders,
-      },
-    }
-  }
-
-  addDefaultHeaders (options) {
-    const { userAgent } = this.options
-    return this.addHeaders({
-      options,
-      headers: {
-        'User-Agent': userAgent,
-      },
-    })
-  }
+// https://www.npmjs.com/package/extract-files/v/6.0.0#type-extractablefilematcher
+function isExtractableFile (value) {
+  return value instanceof fs.ReadStream || value instanceof Buffer
 }
 
 function getRetryMS (retryAfterSeconds) {

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,0 +1,35 @@
+const fs = require('fs')
+
+// https://www.npmjs.com/package/extract-files/v/6.0.0#type-extractablefilematcher
+function isFile (value) {
+  return value instanceof fs.ReadStream || value instanceof Buffer
+}
+
+function graphQLUploadSchemaIsValid (schema, parent) {
+  if (schema instanceof Array) {
+    return schema.every((subSchema) => graphQLUploadSchemaIsValid(subSchema, schema))
+  }
+
+  if (schema.constructor.name === 'Object') {
+    return Object.entries(schema).every(([_key, subSchema]) => graphQLUploadSchemaIsValid(subSchema, schema))
+  }
+
+  if (!isFile(schema)) {
+    return true
+  }
+
+  if (!parent) {
+    return false
+  }
+
+  if (parent.file !== schema) {
+    return false
+  }
+
+  return ['name', 'mimetype'].every((requiredKey) => parent[requiredKey])
+}
+
+module.exports = {
+  isFile,
+  graphQLUploadSchemaIsValid,
+}

--- a/src/validation.js
+++ b/src/validation.js
@@ -5,28 +5,51 @@ function isFile (value) {
   return value instanceof fs.ReadStream || value instanceof Buffer
 }
 
-function graphQLUploadSchemaIsValid (schema, parent) {
-  if (schema instanceof Array) {
-    return schema.every((subSchema) => graphQLUploadSchemaIsValid(subSchema, schema))
-  }
-
-  if (schema.constructor.name === 'Object') {
-    return Object.entries(schema).every(([_key, subSchema]) => graphQLUploadSchemaIsValid(subSchema, schema))
-  }
-
-  if (!isFile(schema)) {
+function graphQLUploadSchemaIsValid (schema, parent, key) {
+  if (typeof schema === 'undefined') {
     return true
   }
 
+  // Not a great/easy/worthwhile way to determine if a string is base64-encoded data,
+  // so our best proxy is to check the keyname
+  if (key !== 'base64File') {
+    if (schema instanceof Array) {
+      return schema.every((subSchema) => graphQLUploadSchemaIsValid(subSchema, schema))
+    }
+
+    if (schema.constructor.name === 'Object') {
+      return Object.entries(schema).every(([key, subSchema]) => graphQLUploadSchemaIsValid(subSchema, schema, key))
+    }
+
+    if (!isFile(schema)) {
+      return true
+    }
+  }
+
+  // All flavors should be nested, and not top-level
   if (!parent) {
     return false
   }
 
-  if (parent.file !== schema) {
-    return false
+  // File Upload
+  if (key === 'file') {
+    if (parent.file !== schema) {
+      return false
+    }
+
+    return ['name', 'mimetype'].every((requiredKey) => parent[requiredKey])
   }
 
-  return ['name', 'mimetype'].every((requiredKey) => parent[requiredKey])
+  // Base64 Upload
+  if (key === 'base64File') {
+    if (parent.base64File !== schema) {
+      return false
+    }
+
+    return ['filename', 'mimetype'].every((requiredKey) => schema[requiredKey])
+  }
+
+  return false
 }
 
 module.exports = {

--- a/src/validation.js
+++ b/src/validation.js
@@ -10,7 +10,7 @@ function graphQLUploadSchemaIsValid (schema, parent, key) {
     return true
   }
 
-  // Not a great/easy/worthwhile way to determine if a string is base64-encoded data,
+  // There is not a great/easy/worthwhile way to determine if a string is base64-encoded data,
   // so our best proxy is to check the keyname
   if (key !== 'base64File') {
     if (schema instanceof Array) {

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,30 @@
+module.exports = {
+  extends: '../.eslintrc.js',
+  env: {
+    mocha: true
+  },
+  globals: {
+    expect: 'readonly',
+    should: 'readonly',
+    sinon : 'readonly',
+    mount : 'readonly',
+    render : 'readonly',
+    shallow : 'readonly',
+    //*************************************************
+    // bdd-lazy-var
+    //
+    // In order to get around eslint complaining for now:
+    // https://github.com/stalniy/bdd-lazy-var/issues/56#issuecomment-639248242
+    $: 'readonly',
+    its: 'readonly',
+    def: 'readonly',
+    subject: 'readonly',
+    get: 'readonly',
+    sharedExamplesFor: 'readonly',
+    includeExamplesFor: 'readonly',
+    itBehavesLike: 'readonly',
+    is: 'readonly'
+    //
+    //*************************************************
+  }
+}

--- a/test/mocha.js
+++ b/test/mocha.js
@@ -1,0 +1,18 @@
+'use strict'
+
+module.exports = {
+  diff: true,
+  delay: false,
+  extension: ['js'],
+  package: './package.json',
+  reporter: 'spec',
+  slow: 75,
+  timeout: 2000,
+  spec: './test/**/*.test.js',
+  require: [
+    './test/environment.js',
+  ],
+  file: './test/setup.js',
+  ui: 'bdd-lazy-var/getter',
+  exit: true,
+}

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,5 @@
+const { get } = require('bdd-lazy-var/getter')
+
+// In order to get around eslint complaining for now:
+// https://github.com/stalniy/bdd-lazy-var/issues/56#issuecomment-639248242
+global.$ = get

--- a/yarn.lock
+++ b/yarn.lock
@@ -1493,7 +1493,7 @@ locate-path@^5.0.0:
 
 lodash.get@^4.4.2:
   version "4.4.2"
-  resolved "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
 lodash.uniqby@^4.7.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,6 +135,13 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 acorn-jsx@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
@@ -909,6 +916,11 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 execa@^0.7.0:
   version "0.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -246,6 +246,11 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
 auto-changelog@^1.16.2:
   version "1.16.2"
   resolved "https://registry.yarnpkg.com/auto-changelog/-/auto-changelog-1.16.2.tgz#4b08b7cbd07fdbd9139c6e06ea0b704db3f5485c"
@@ -475,6 +480,13 @@ color-name@~1.1.4:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
@@ -593,6 +605,11 @@ define-properties@^1.1.2, define-properties@^1.1.3:
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   dependencies:
     object-keys "^1.0.12"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
 diff@3.5.0:
   version "3.5.0"
@@ -915,6 +932,11 @@ external-editor@^3.0.3:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
+extract-files@^6:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-6.0.0.tgz#a273fd666aac97fd32e788b62d72d978bf43bb71"
+  integrity sha512-v9UVTPkERZR1NjEOIPvmbzLFdh8YZFEGjRdSJraop6HJe9PQ8HU9iv6eRMuF06CXXXO/R5OBmnWMixZHuZ8CsA==
+
 fast-deep-equal@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
@@ -993,6 +1015,15 @@ flatted@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
+
+form-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1508,6 +1539,18 @@ make-dir@^1.0.0:
   integrity sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==
   dependencies:
     pify "^3.0.0"
+
+mime-db@1.44.0:
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
+  integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
+
+mime-types@^2.1.12, mime-types@^2.1.27:
+  version "2.1.27"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
+  integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
+  dependencies:
+    mime-db "1.44.0"
 
 mimic-fn@^2.1.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -289,6 +289,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+bdd-lazy-var@^2.5.4:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/bdd-lazy-var/-/bdd-lazy-var-2.5.4.tgz#1b4cafd7c7f15b1f99087a18619610ef81138349"
+  integrity sha512-U7lk5UWkAVnvfG7y578byFatVwFEugwD7Y1mHIih/7L1QkhTkEAwBvXER0SftI4UxTWZnNF0dA9mDJ4tycTZpg==
+
 binary-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"


### PR DESCRIPTION
## Description of the change

In concert with the big [changes](https://github.com/anvilco/anvil/pull/1529/files) to the `createEtchPacket` mutation, we'll want to add robust support for that mutation in this, our Node API client. This client previously did not have any support for GraphQL whatsoever, so it had to also be added in this PR.

Here are the big things going on:
- Adds ability to do basic GraphQL queries and mutations
- Adds ability to create `graphql-upload`-compliant structures, allowing for files to be uploaded in a GraphQL mutation
- Adds some helpers to make it easier for users to deal with uploading Streams, Buffers, or even Base64-encoded data/files to us
- Performs some light schema validation...at least when it comes to file uploads (since they require an oddly specific format).
- Add a relevant example
- Update the README/docs to let 'em know about this stuff
- A number of private, undocumented helpers and such that we can show people in a pinch, or perhaps guide some towards using.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] No previous tests unrelated to the changed code fail in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] At least one reviewer has been requested
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The relevant project board has been selected in Projects to auto-link to this pull request
