### PR TITLE
rename send to draft (and flip the logic) in createEtchPacket

### DIFF
--- a/example/script/create-etch-packet.js
+++ b/example/script/create-etch-packet.js
@@ -19,7 +19,7 @@ async function main () {
   const streamFile = Anvil.prepareGraphQLFile(pathToFile)
 
   const variables = {
-    draft: false,
+    isDraft: false,
     isTest: true,
     signatureEmailSubject: 'Test Create Packet',
     signers: [

--- a/example/script/create-etch-packet.js
+++ b/example/script/create-etch-packet.js
@@ -19,7 +19,7 @@ async function main () {
   const streamFile = Anvil.prepareGraphQLFile(pathToFile)
 
   const variables = {
-    send: true,
+    draft: false,
     isTest: true,
     signatureEmailSubject: 'Test Create Packet',
     signers: [

--- a/src/graphql/mutations/createEtchPacket.js
+++ b/src/graphql/mutations/createEtchPacket.js
@@ -22,7 +22,7 @@ module.exports = {
     mutation CreateEtchPacket (
       $name: String,
       $files: [EtchFile!],
-      $send: Boolean,
+      $draft: Boolean,
       $isTest: Boolean,
       $signatureEmailSubject: String,
       $signatureEmailBody: String,
@@ -33,7 +33,7 @@ module.exports = {
       createEtchPacket (
         name: $name,
         files: $files,
-        send: $send,
+        draft: $draft,
         isTest: $isTest,
         signatureEmailSubject: $signatureEmailSubject,
         signatureEmailBody: $signatureEmailBody,

--- a/src/graphql/mutations/createEtchPacket.js
+++ b/src/graphql/mutations/createEtchPacket.js
@@ -22,7 +22,7 @@ module.exports = {
     mutation CreateEtchPacket (
       $name: String,
       $files: [EtchFile!],
-      $draft: Boolean,
+      $isDraft: Boolean,
       $isTest: Boolean,
       $signatureEmailSubject: String,
       $signatureEmailBody: String,
@@ -33,7 +33,7 @@ module.exports = {
       createEtchPacket (
         name: $name,
         files: $files,
-        draft: $draft,
+        isDraft: $isDraft,
         isTest: $isTest,
         signatureEmailSubject: $signatureEmailSubject,
         signatureEmailBody: $signatureEmailBody,


### PR DESCRIPTION
## Description of the change

rename send to draft (and flip the logic) in createEtchPacket.

I have manually tested this against the changes in https://github.com/anvilco/anvil/pull/1632 and it works as expected.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] No previous tests unrelated to the changed code fail in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [x] At least one reviewer has been requested
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The relevant project board has been selected in Projects to auto-link to this pull request
