### PR TITLE
Add `aliasId` AND `routingOrder` to `createEtchPacket` mutation query response default

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,22 @@ Creates an Etch Packet and optionally sends it to the first signer.
 * `options` (Object) - An object with the following structure:
   * `variables` (Object) - See the [API Documentation](#api-documentation) area for details. See [Examples](#examples) area for examples.
   * `responseQuery` (String) - _optional_ A GraphQL Query compliant query to use for the data desired in the mutation response. Can be left out to use default.
+  * `mutation` (String) - _optional_ If you'd like complete control of the GraphQL mutation, you can pass in a GraphQL Mutation compliant string that will be used in the mutation call. This string should also include your response query, as the `responseQuery` param is ignored if `mutation` is passed. Example:
+    ```graphql
+      mutation CreateEtchPacket (
+        $name: String,
+        ...
+      ) {
+        createEtchPacket (
+          name: $name,
+          ...
+        ) {
+          id
+          eid
+          ...
+        }
+      }
+    ```
 
 ##### generateEtchSignUrl(options)
 

--- a/src/graphql/mutations/createEtchPacket.js
+++ b/src/graphql/mutations/createEtchPacket.js
@@ -12,6 +12,7 @@ const defaultResponseQuery = `{
       id
       eid
       aliasId
+      routingOrder
       name
       email
     }

--- a/src/graphql/mutations/createEtchPacket.js
+++ b/src/graphql/mutations/createEtchPacket.js
@@ -11,6 +11,7 @@ const defaultResponseQuery = `{
     signers {
       id
       eid
+      aliasId
       name
       email
     }

--- a/src/index.js
+++ b/src/index.js
@@ -108,10 +108,10 @@ class Anvil {
     )
   }
 
-  createEtchPacket ({ variables, responseQuery }) {
+  createEtchPacket ({ variables, responseQuery, mutation }) {
     return this.requestGraphQL(
       {
-        query: getCreateEtchPacketMutation(responseQuery),
+        query: mutation || getCreateEtchPacketMutation(responseQuery),
         variables,
       },
       { dataType: DATA_TYPE_JSON },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -380,6 +380,27 @@ describe('Anvil API Client', function () {
         client.requestGraphQL.restore()
       })
 
+      context('mutation is specified', function () {
+        it('calls requestGraphQL with overridden mutation', function () {
+          const variables = { foo: 'bar' }
+          const mutationOverride = 'createEtchPacketOverride()'
+
+          client.createEtchPacket({ variables, mutation: mutationOverride })
+
+          expect(client.requestGraphQL).to.have.been.calledOnce
+          const [options, clientOptions] = client.requestGraphQL.lastCall.args
+
+          const {
+            query,
+            variables: variablesReceived,
+          } = options
+
+          expect(variables).to.eql(variablesReceived)
+          expect(query).to.include(mutationOverride)
+          expect(clientOptions).to.eql({ dataType: 'json' })
+        })
+      })
+
       context('no responseQuery specified', function () {
         it('calls requestGraphQL with default responseQuery', function () {
           const variables = { foo: 'bar' }
@@ -403,7 +424,6 @@ describe('Anvil API Client', function () {
       context('responseQuery specified', function () {
         it('calls requestGraphQL with overridden responseQuery', function () {
           const variables = { foo: 'bar' }
-
           const responseQuery = 'onlyInATest {}'
 
           client.createEtchPacket({ variables, responseQuery })


### PR DESCRIPTION
## Description of the change

Add `aliasId` AND `routingOrder` to `createEtchPacket` mutation response query default so that users can correlate the resulting `signers`.

Also allow the user to easily specify the entire mutation string if they so choose...this is mostly in case we break something in the schema accidentally, but also gives the user power if they want it.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes #1

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] No previous tests unrelated to the changed code fail in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] At least one reviewer has been requested
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The relevant project board has been selected in Projects to auto-link to this pull request
