### PR TITLE
Add getEtchPacket and downloadDocuments Methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_STORE
 *.log
+*.zip
 
 node_modules
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -147,6 +147,17 @@ Generates an Etch sign URL for an Etch Packet signer. The Etch Packet and its si
     * `clientUserId` (String) - your user eid
     * `signerEid` (String) - the eid of the Etch Packet signer, found in the response of the `createEtchPacket` instance method
 
+##### downloadDocuments(documentGroupEid)
+
+Returns the PassThrough stream of the document group specified by the documentGroupEid in Zip file format.
+* `documentGroupEid` (string) - the eid of the document group you wish to download
+* Returns a `Promise` that resolves to an `Object`
+   * `statusCode` (Number) - the HTTP status code, `200` is success
+   * `response` (Object) - the Response object resulting from the client's request to the Anvil app
+   * `data` (object) - a PassThrough Stream object containing the document group's data in Zip file format
+   * `errors` (Array of Objects) - Will be present if status >= 400. See Errors
+      * `message` (String)
+
 ### Class Methods
 
 ##### prepareGraphQLFile(pathOrStreamLikeThing[, options])

--- a/README.md
+++ b/README.md
@@ -137,17 +137,7 @@ Gets the details of an Etch Packet.
 * `options` (Object) - An object with the following structure:
   * `variables` (Object) - Requires `eid`
     * `eid` (String) - your Etch Packet eid
-  * `responseQuery` (String) - _optional_ A GraphQL Query compliant query to use for the data desired in the mutation response. Can be left out to use default.
-  * `query` (String) - _optional_ If you'd like complete control of the GraphQL query, you can pass in a GraphQL Query compliant string that will be used in the query call. This string should also include your response query, as the `responseQuery` param is ignored if `query` is passed. Example:
-    ```graphql
-      query GetEtchPacket (
-        $eid: String!,
-      ) {
-        etchPacket (
-          eid: $eid,
-        ) ${responseQuery}
-      }
-    ```
+  * `responseQuery` (String) - _optional_ A GraphQL Query compliant query to use for the data desired in the query response. Can be left out to use default.
 
 ##### generateEtchSignUrl(options)
 

--- a/README.md
+++ b/README.md
@@ -147,10 +147,12 @@ Generates an Etch sign URL for an Etch Packet signer. The Etch Packet and its si
     * `clientUserId` (String) - your user eid
     * `signerEid` (String) - the eid of the Etch Packet signer, found in the response of the `createEtchPacket` instance method
 
-##### downloadDocuments(documentGroupEid)
+##### downloadDocuments(documentGroupEid[, options])
 
 Returns the PassThrough stream of the document group specified by the documentGroupEid in Zip file format.
 * `documentGroupEid` (string) - the eid of the document group to download
+* `options` (Object) - _optional_ Any additional options for the request
+  * `dataType` (Enum[String]) - _optional_ Set the type of the `data` value that is returned in the resolved `Promise`. Defaults to `'buffer'`, but `'stream'` is also supported.
 * Returns a `Promise` that resolves to an `Object`
    * `statusCode` (Number) - the HTTP status code, `200` is success
    * `response` (Object) - the Response object resulting from the client's request to the Anvil app

--- a/README.md
+++ b/README.md
@@ -131,6 +131,24 @@ Creates an Etch Packet and optionally sends it to the first signer.
       }
     ```
 
+##### getEtchPacket(options)
+
+Gets the details of an Etch Packet.
+* `options` (Object) - An object with the following structure:
+  * `variables` (Object) - Requires `eid`
+    * `eid` (String) - your Etch Packet eid
+  * `responseQuery` (String) - _optional_ A GraphQL Query compliant query to use for the data desired in the mutation response. Can be left out to use default.
+  * `query` (String) - _optional_ If you'd like complete control of the GraphQL query, you can pass in a GraphQL Query compliant string that will be used in the query call. This string should also include your response query, as the `responseQuery` param is ignored if `query` is passed. Example:
+    ```graphql
+      query GetEtchPacket (
+        $eid: String!,
+      ) {
+        etchPacket (
+          eid: $eid,
+        ) ${responseQuery}
+      }
+    ```
+
 ##### generateEtchSignUrl(options)
 
 Generates an Etch sign URL for an Etch Packet signer. The Etch Packet and its signers must have already been created.

--- a/README.md
+++ b/README.md
@@ -149,14 +149,14 @@ Generates an Etch sign URL for an Etch Packet signer. The Etch Packet and its si
 
 ##### downloadDocuments(documentGroupEid[, options])
 
-Returns the PassThrough stream of the document group specified by the documentGroupEid in Zip file format.
+Returns a Buffer or Stream of the document group specified by the documentGroupEid in Zip file format.
 * `documentGroupEid` (string) - the eid of the document group to download
 * `options` (Object) - _optional_ Any additional options for the request
   * `dataType` (Enum[String]) - _optional_ Set the type of the `data` value that is returned in the resolved `Promise`. Defaults to `'buffer'`, but `'stream'` is also supported.
 * Returns a `Promise` that resolves to an `Object`
    * `statusCode` (Number) - the HTTP status code, `200` is success
    * `response` (Object) - the Response object resulting from the client's request to the Anvil app
-   * `data` (object) - a PassThrough Stream object containing the document group's data in Zip file format
+   * `data` (Buffer | Stream) - The raw binary data of the downloaded document if success. Will be in the format of either a Buffer or a Stream, depending on `dataType` option supplied to the request.
    * `errors` (Array of Objects) - Will be present if status >= 400. See Errors
       * `message` (String)
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Generates an Etch sign URL for an Etch Packet signer. The Etch Packet and its si
 ##### downloadDocuments(documentGroupEid)
 
 Returns the PassThrough stream of the document group specified by the documentGroupEid in Zip file format.
-* `documentGroupEid` (string) - the eid of the document group you wish to download
+* `documentGroupEid` (string) - the eid of the document group to download
 * Returns a `Promise` that resolves to an `Object`
    * `statusCode` (Number) - the HTTP status code, `200` is success
    * `response` (Object) - the Response object resulting from the client's request to the Anvil app

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Returns a Buffer or Stream of the document group specified by the documentGroupE
 * Returns a `Promise` that resolves to an `Object`
    * `statusCode` (Number) - the HTTP status code, `200` is success
    * `response` (Object) - the Response object resulting from the client's request to the Anvil app
-   * `data` (Buffer | Stream) - The raw binary data of the downloaded document if success. Will be in the format of either a Buffer or a Stream, depending on `dataType` option supplied to the request.
+   * `data` (Buffer | Stream) - The raw binary data of the downloaded documents if success. Will be in the format of either a Buffer or a Stream, depending on `dataType` option supplied to the request.
    * `errors` (Array of Objects) - Will be present if status >= 400. See Errors
       * `message` (String)
 

--- a/example/README.md
+++ b/example/README.md
@@ -72,7 +72,7 @@ yarn node example/script/generate-etch-sign-url.js WHG3ylq0EE930IR2LZDtgoqgl55M3
 
 ## download-documents.js script
 
-Calls the downloadDocuments Anvil endpoint to download documents with the specified documentGroupEid in Zip file format. Outputs the downloaded Zip file in `example/script/{documentGroupName}.zip`
+Calls the downloadDocuments Anvil endpoint to download documents with the specified documentGroupEid in Zip file format. Outputs the downloaded Zip file in `example/script/{etchPacketName}.zip`
 
 Usage example:
 

--- a/example/README.md
+++ b/example/README.md
@@ -42,6 +42,20 @@ yarn node example/script/create-etch-packet.js <apiKey> <castEid> <filename>
 yarn node example/script/create-etch-packet.js WHG3ylq0EE930IR2LZDtgoqgl55M3TwQ 99u7QvvHr8hDQ4BW9GYv ../../../simple-anvil-finovate-non-qualified.pdf
 ```
 
+## get-etch-packet.js script
+
+Calls the etchPacket Anvil endpoint with the specified Etch packet eid to get the packet details. 
+
+Usage example:
+
+```sh
+# Gets the details of an Etch Packet, a packet eid must be supplied
+yarn node example/script/get-etch-packet.js <apiKey> <etchPacketEid>
+
+# An example
+yarn node example/script/get-etch-packet.js WHG3ylq0EE930IR2LZDtgoqgl55M3TwQ QJhbdpK75RHRQcgPz5Fc
+```
+
 ## generate-etch-sign-url.js script
 
 Calls the generateEtchSignUrl Anvil endpoint with data specified to generate an Etch sign link with the Anvil API. Returns the sign link.

--- a/example/README.md
+++ b/example/README.md
@@ -72,7 +72,7 @@ yarn node example/script/generate-etch-sign-url.js WHG3ylq0EE930IR2LZDtgoqgl55M3
 
 ## download-documents.js script
 
-Calls the downloadDocuments Anvil endpoint to download documents with the specified documentGroupEid in Zip file format. Outputs the downloaded Zip file in `example/script/{etchPacketName}.zip`
+Calls the downloadDocuments Anvil endpoint to download documents with the specified documentGroupEid in Zip file format. Outputs the downloaded Zip file in `example/script/{etchPacketName}.zip`. The default response data is returned in the form of a buffer. This can be changed by adding the `-s` flag to instead be returned as a PassThrough stream.
 
 Usage example:
 

--- a/example/README.md
+++ b/example/README.md
@@ -69,3 +69,17 @@ yarn node example/script/generate-etch-sign-url.js <apiKey> <clientUserId> <sign
 # An example
 yarn node example/script/generate-etch-sign-url.js WHG3ylq0EE930IR2LZDtgoqgl55M3TwQ eBim2Vsv2GqCTJxpjTru ZTlbNhxP2lGkNFsNzcus
 ```
+
+## download-documents.js script
+
+Calls the downloadDocuments Anvil endpoint to download documents with the specified documentGroupEid in Zip file format. Outputs the downloaded Zip file in `example/script/{documentGroupName}.zip`
+
+Usage example:
+
+```sh
+# Downloads a Document Group in a Zip file and outputs in the example/script folder
+yarn node example/script/download-documents.js <apiKey> <documentGroupEid>
+
+# An example
+yarn node example/script/download-documents.js WHG3ylq0EE930IR2LZDtgoqgl55M3TwQ uQiXw4P4DTmXV1eNDmzH
+```

--- a/example/script/download-documents.js
+++ b/example/script/download-documents.js
@@ -1,0 +1,42 @@
+const fs = require('fs')
+const path = require('path')
+const Anvil = require('../../src/index')
+const argv = require('yargs')
+  .usage('Usage: $0 apiKey documentGroupEid')
+  .demandCommand(2).argv
+
+const [apiKey, documentGroupEid] = argv._
+
+async function main () {
+  const clientOptions = {
+    apiKey,
+  }
+
+  const client = new Anvil(clientOptions)
+
+  const { statusCode, response, data, errors } = await client.downloadDocuments(documentGroupEid)
+  if (statusCode === 200) {
+    const contentDisposition = response.headers.get('content-disposition')
+    const fileTitle = contentDisposition.split('"')[1]
+    const scriptDir = __dirname
+    const outputFilePath = path.join(scriptDir, fileTitle)
+    const writeStream = fs.createWriteStream(outputFilePath, { encoding: null })
+    await new Promise((resolve, reject) => {
+      data.pipe(writeStream)
+      data.on('error', reject)
+      writeStream.on('finish', resolve)
+    })
+    console.log(statusCode, data)
+  } else {
+    console.log(statusCode, JSON.stringify(errors || data, null, 2))
+  }
+}
+
+main()
+  .then(() => {
+    process.exit(0)
+  })
+  .catch((err) => {
+    console.log(err.stack || err.message)
+    process.exit(1)
+  })

--- a/example/script/download-documents.js
+++ b/example/script/download-documents.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const Anvil = require('../../src/index')
 const argv = require('yargs')
-  .usage('Usage: $0 apiKey documentGroupEid')
+  .usage('Usage: $0 apiKey documentGroupEid [-s]')
   .option('stream', {
     alias: 's',
     type: 'boolean',

--- a/example/script/download-documents.js
+++ b/example/script/download-documents.js
@@ -3,9 +3,15 @@ const path = require('path')
 const Anvil = require('../../src/index')
 const argv = require('yargs')
   .usage('Usage: $0 apiKey documentGroupEid')
+  .option('stream', {
+    alias: 's',
+    type: 'boolean',
+    description: 'Return the data as a stream (default is buffer)',
+  })
   .demandCommand(2).argv
 
 const [apiKey, documentGroupEid] = argv._
+const returnAStream = argv.stream
 
 async function main () {
   const clientOptions = {
@@ -14,21 +20,30 @@ async function main () {
 
   const client = new Anvil(clientOptions)
 
-  const { statusCode, response, data, errors } = await client.downloadDocuments(documentGroupEid)
+  const downloadOptions = {}
+  if (returnAStream) downloadOptions.dataType = 'stream'
+
+  const { statusCode, response, data, errors } = await client.downloadDocuments(documentGroupEid, downloadOptions)
   if (statusCode === 200) {
     const contentDisposition = response.headers.get('content-disposition')
     const fileTitle = contentDisposition.split('"')[1]
     const scriptDir = __dirname
     const outputFilePath = path.join(scriptDir, fileTitle)
-    const writeStream = fs.createWriteStream(outputFilePath, { encoding: null })
-    await new Promise((resolve, reject) => {
-      data.pipe(writeStream)
-      data.on('error', reject)
-      writeStream.on('finish', resolve)
-    })
-    console.log(statusCode, data)
+
+    if (returnAStream) {
+      const writeStream = fs.createWriteStream(outputFilePath, { encoding: null })
+      await new Promise((resolve, reject) => {
+        data.pipe(writeStream)
+        data.on('error', reject)
+        writeStream.on('finish', resolve)
+      })
+    } else {
+      fs.writeFileSync(outputFilePath, data, { encoding: null })
+    }
+
+    console.log(statusCode)
   } else {
-    console.log(statusCode, JSON.stringify(errors || data, null, 2))
+    console.log(statusCode, JSON.stringify(errors, null, 2))
   }
 }
 

--- a/example/script/get-etch-packet.js
+++ b/example/script/get-etch-packet.js
@@ -1,0 +1,36 @@
+const Anvil = require('../../src/index')
+const argv = require('yargs')
+  .usage('Usage: $0 apiKey etchPacketEid')
+  .demandCommand(2).argv
+
+const [apiKey, etchPacketEid] = argv._
+
+async function main () {
+  const clientOptions = {
+    apiKey,
+  }
+
+  const client = new Anvil(clientOptions)
+
+  const variables = {
+    eid: etchPacketEid,
+  }
+
+  const { statusCode, data, errors } = await client.getEtchPacket({ variables })
+  console.log(
+    JSON.stringify({
+      statusCode,
+      data,
+      errors,
+    }, null, 2),
+  )
+}
+
+main()
+  .then(() => {
+    process.exit(0)
+  })
+  .catch((err) => {
+    console.log(err.stack || err.message)
+    process.exit(1)
+  })

--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -1,5 +1,7 @@
 const mutations = require('./mutations')
+const queries = require('./queries')
 
 module.exports = {
   mutations,
+  queries,
 }

--- a/src/graphql/mutations/createEtchPacket.js
+++ b/src/graphql/mutations/createEtchPacket.js
@@ -18,6 +18,7 @@ const defaultResponseQuery = `{
       name
       email
       status
+      signActionType
     }
   }
 }`

--- a/src/graphql/mutations/createEtchPacket.js
+++ b/src/graphql/mutations/createEtchPacket.js
@@ -8,7 +8,6 @@ const defaultResponseQuery = `{
     eid
     status
     files
-    providerConfig
     signers {
       id
       eid

--- a/src/graphql/mutations/createEtchPacket.js
+++ b/src/graphql/mutations/createEtchPacket.js
@@ -3,6 +3,7 @@ const defaultResponseQuery = `{
   id
   eid
   name
+  etchPacketDetailsURL
   documentGroup {
     id
     eid

--- a/src/graphql/mutations/createEtchPacket.js
+++ b/src/graphql/mutations/createEtchPacket.js
@@ -20,7 +20,7 @@ const defaultResponseQuery = `{
 }`
 
 module.exports = {
-  getMutation: (responseQuery = defaultResponseQuery) => `
+  generateMutation: (responseQuery = defaultResponseQuery) => `
     mutation CreateEtchPacket (
       $name: String,
       $files: [EtchFile!],

--- a/src/graphql/mutations/createEtchPacket.js
+++ b/src/graphql/mutations/createEtchPacket.js
@@ -9,7 +9,6 @@ const defaultResponseQuery = `{
     eid
     status
     files
-    downloadZipURL
     signers {
       id
       eid

--- a/src/graphql/mutations/createEtchPacket.js
+++ b/src/graphql/mutations/createEtchPacket.js
@@ -8,6 +8,7 @@ const defaultResponseQuery = `{
     eid
     status
     files
+    providerConfig
     signers {
       id
       eid
@@ -15,6 +16,7 @@ const defaultResponseQuery = `{
       routingOrder
       name
       email
+      status
     }
   }
 }`

--- a/src/graphql/mutations/createEtchPacket.js
+++ b/src/graphql/mutations/createEtchPacket.js
@@ -9,6 +9,7 @@ const defaultResponseQuery = `{
     eid
     status
     files
+    downloadZipURL
     signers {
       id
       eid

--- a/src/graphql/mutations/createEtchPacket.js
+++ b/src/graphql/mutations/createEtchPacket.js
@@ -3,7 +3,7 @@ const defaultResponseQuery = `{
   id
   eid
   name
-  etchPacketDetailsURL
+  detailsURL
   documentGroup {
     id
     eid

--- a/src/graphql/mutations/generateEtchSignUrl.js
+++ b/src/graphql/mutations/generateEtchSignUrl.js
@@ -1,5 +1,5 @@
 module.exports = {
-  getMutation: () => `
+  generateMutation: () => `
     mutation GenerateEtchSignURL (
       $signerEid: String!,
       $clientUserId: String!,

--- a/src/graphql/queries/etchPacket.js
+++ b/src/graphql/queries/etchPacket.js
@@ -7,6 +7,7 @@ const defaultResponseQuery = `{
     eid
     status
     files
+    providerConfig
     signers {
       id
       eid

--- a/src/graphql/queries/etchPacket.js
+++ b/src/graphql/queries/etchPacket.js
@@ -2,6 +2,7 @@ const defaultResponseQuery = `{
   id
   eid
   name
+  etchPacketDetailsURL
   documentGroup {
     id
     eid

--- a/src/graphql/queries/etchPacket.js
+++ b/src/graphql/queries/etchPacket.js
@@ -17,6 +17,7 @@ const defaultResponseQuery = `{
       name
       email
       status
+      signActionType
     }
   }
 }`

--- a/src/graphql/queries/etchPacket.js
+++ b/src/graphql/queries/etchPacket.js
@@ -1,0 +1,31 @@
+const defaultResponseQuery = `{
+  id
+  eid
+  name
+  documentGroup {
+    id
+    eid
+    status
+    files
+    signers {
+      id
+      eid
+      aliasId
+      routingOrder
+      name
+      email
+    }
+  }
+}`
+
+module.exports = {
+  getQuery: (responseQuery = defaultResponseQuery) => `
+    query GetEtchPacket (
+      $eid: String!,
+    ) {
+      etchPacket (
+        eid: $eid,
+      ) ${responseQuery}
+    }
+  `,
+}

--- a/src/graphql/queries/etchPacket.js
+++ b/src/graphql/queries/etchPacket.js
@@ -15,6 +15,7 @@ const defaultResponseQuery = `{
       routingOrder
       name
       email
+      status
     }
   }
 }`

--- a/src/graphql/queries/etchPacket.js
+++ b/src/graphql/queries/etchPacket.js
@@ -19,7 +19,7 @@ const defaultResponseQuery = `{
 }`
 
 module.exports = {
-  getQuery: (responseQuery = defaultResponseQuery) => `
+  generateQuery: (responseQuery = defaultResponseQuery) => `
     query GetEtchPacket (
       $eid: String!,
     ) {

--- a/src/graphql/queries/etchPacket.js
+++ b/src/graphql/queries/etchPacket.js
@@ -2,7 +2,7 @@ const defaultResponseQuery = `{
   id
   eid
   name
-  etchPacketDetailsURL
+  detailsURL
   documentGroup {
     id
     eid

--- a/src/graphql/queries/etchPacket.js
+++ b/src/graphql/queries/etchPacket.js
@@ -8,6 +8,7 @@ const defaultResponseQuery = `{
     eid
     status
     files
+    downloadZipURL
     signers {
       id
       eid

--- a/src/graphql/queries/etchPacket.js
+++ b/src/graphql/queries/etchPacket.js
@@ -8,7 +8,6 @@ const defaultResponseQuery = `{
     eid
     status
     files
-    downloadZipURL
     signers {
       id
       eid

--- a/src/graphql/queries/etchPacket.js
+++ b/src/graphql/queries/etchPacket.js
@@ -7,7 +7,6 @@ const defaultResponseQuery = `{
     eid
     status
     files
-    providerConfig
     signers {
       id
       eid

--- a/src/graphql/queries/index.js
+++ b/src/graphql/queries/index.js
@@ -1,0 +1,11 @@
+const fs = require('fs')
+
+const IGNORE_FILES = ['index.js']
+
+module.exports = fs.readdirSync(__dirname)
+  .filter((fileName) => (fileName.endsWith('.js') && !fileName.startsWith('.') && !IGNORE_FILES.includes(fileName)))
+  .reduce((acc, fileName) => {
+    const queryName = fileName.slice(0, fileName.length - 3)
+    acc[queryName] = require(`./${queryName}`)
+    return acc
+  }, {})

--- a/src/index.js
+++ b/src/index.js
@@ -151,7 +151,7 @@ class Anvil {
 
   downloadDocuments (documentGroupEid) {
     return this.requestREST(
-      `/api/document-group/${documentGroupEid}.zip`,
+      `/api/client/document-group/${documentGroupEid}.zip`,
       { method: 'GET' },
       { dataType: DATA_TYPE_STREAM })
   }

--- a/src/index.js
+++ b/src/index.js
@@ -149,8 +149,11 @@ class Anvil {
     }
   }
 
-  async downloadDocumentGroup (documentGroupEid, clientOptions = { dataType: DATA_TYPE_BUFFER }) {
-    return this.requestREST(`/api/document-group/${documentGroupEid}.zip`, { method: 'GET' }, clientOptions)
+  downloadDocuments (documentGroupEid) {
+    return this.requestREST(
+      `/api/document-group/${documentGroupEid}.zip`,
+      { method: 'GET' },
+      { dataType: DATA_TYPE_STREAM })
   }
 
   async requestGraphQL ({ query, variables = {} }, clientOptions) {

--- a/src/index.js
+++ b/src/index.js
@@ -12,15 +12,15 @@ const { version, description } = require('../package.json')
 const {
   mutations: {
     createEtchPacket: {
-      getMutation: getCreateEtchPacketMutation,
+      generateMutation: generateCreateEtchPacketMutation,
     },
     generateEtchSignUrl: {
-      getMutation: getGenerateEtchSignUrlMutation,
+      generateMutation: generateGenerateEtchSignUrlMutation,
     },
   },
   queries: {
     etchPacket: {
-      getQuery: getEtchPacketQuery,
+      generateQuery: generateEtchPacketQuery,
     },
   },
 } = require('./graphql')
@@ -116,17 +116,17 @@ class Anvil {
   createEtchPacket ({ variables, responseQuery, mutation }) {
     return this.requestGraphQL(
       {
-        query: mutation || getCreateEtchPacketMutation(responseQuery),
+        query: mutation || generateCreateEtchPacketMutation(responseQuery),
         variables,
       },
       { dataType: DATA_TYPE_JSON },
     )
   }
 
-  getEtchPacket ({ variables, responseQuery, query }) {
+  getEtchPacket ({ variables, responseQuery }) {
     return this.requestGraphQL(
       {
-        query: query || getEtchPacketQuery(responseQuery),
+        query: generateEtchPacketQuery(responseQuery),
         variables,
       },
       { dataType: DATA_TYPE_JSON },
@@ -136,7 +136,7 @@ class Anvil {
   async generateEtchSignUrl ({ variables }) {
     const { statusCode, data, errors } = await this.requestGraphQL(
       {
-        query: getGenerateEtchSignUrlMutation(),
+        query: generateGenerateEtchSignUrlMutation(),
         variables,
       },
       { dataType: DATA_TYPE_JSON },

--- a/src/index.js
+++ b/src/index.js
@@ -149,6 +149,10 @@ class Anvil {
     }
   }
 
+  async downloadDocumentGroup (documentGroupEid, clientOptions = { dataType: DATA_TYPE_BUFFER }) {
+    return this.requestREST(`/api/document-group/${documentGroupEid}.zip`, { method: 'GET' }, clientOptions)
+  }
+
   async requestGraphQL ({ query, variables = {} }, clientOptions) {
     // Some helpful resources on how this came to be:
     // https://github.com/jaydenseric/graphql-upload/issues/125#issuecomment-440853538

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const {
       generateMutation: generateCreateEtchPacketMutation,
     },
     generateEtchSignUrl: {
-      generateMutation: generateGenerateEtchSignUrlMutation,
+      generateMutation: generateEtchSignUrlMutation,
     },
   },
   queries: {
@@ -136,7 +136,7 @@ class Anvil {
   async generateEtchSignUrl ({ variables }) {
     const { statusCode, data, errors } = await this.requestGraphQL(
       {
-        query: generateGenerateEtchSignUrlMutation(),
+        query: generateEtchSignUrlMutation(),
         variables,
       },
       { dataType: DATA_TYPE_JSON },

--- a/src/index.js
+++ b/src/index.js
@@ -149,11 +149,20 @@ class Anvil {
     }
   }
 
-  downloadDocuments (documentGroupEid) {
+  downloadDocuments (documentGroupEid, clientOptions = {}) {
+    const supportedDataTypes = [DATA_TYPE_STREAM, DATA_TYPE_BUFFER]
+    const { dataType = DATA_TYPE_BUFFER } = clientOptions
+    if (dataType && !supportedDataTypes.includes(dataType)) {
+      throw new Error(`dataType must be one of: ${supportedDataTypes.join('|')}`)
+    }
     return this.requestREST(
       `/api/document-group/${documentGroupEid}.zip`,
       { method: 'GET' },
-      { dataType: DATA_TYPE_STREAM })
+      {
+        ...clientOptions,
+        dataType,
+      },
+    )
   }
 
   async requestGraphQL ({ query, variables = {} }, clientOptions) {

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,11 @@ const {
       getMutation: getGenerateEtchSignUrlMutation,
     },
   },
+  queries: {
+    etchPacket: {
+      getQuery: getEtchPacketQuery,
+    },
+  },
 } = require('./graphql')
 
 const {
@@ -112,6 +117,16 @@ class Anvil {
     return this.requestGraphQL(
       {
         query: mutation || getCreateEtchPacketMutation(responseQuery),
+        variables,
+      },
+      { dataType: DATA_TYPE_JSON },
+    )
+  }
+
+  getEtchPacket ({ variables, responseQuery, query }) {
+    return this.requestGraphQL(
+      {
+        query: query || getEtchPacketQuery(responseQuery),
         variables,
       },
       { dataType: DATA_TYPE_JSON },

--- a/src/index.js
+++ b/src/index.js
@@ -151,7 +151,7 @@ class Anvil {
 
   downloadDocuments (documentGroupEid) {
     return this.requestREST(
-      `/api/client/document-group/${documentGroupEid}.zip`,
+      `/api/document-group/${documentGroupEid}.zip`,
       { method: 'GET' },
       { dataType: DATA_TYPE_STREAM })
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,6 +13,7 @@ function mockNodeFetchResponse (options = {}) {
     json,
     buffer,
     headers,
+    body,
   } = options
 
   const mock = {
@@ -25,6 +26,10 @@ function mockNodeFetchResponse (options = {}) {
 
   if (buffer) {
     mock.buffer = () => buffer
+  }
+
+  if (body) {
+    mock.body = body
   }
 
   if (headers) {
@@ -209,6 +214,80 @@ describe('Anvil API Client', function () {
           expect(client._request).to.have.been.calledOnce
           expect(result.statusCode).to.eql(401)
           expect(result.errors).to.eql([error])
+        })
+      })
+    })
+
+    describe('downloadDocuments', function () {
+      def('statusCode', 200)
+      def('buffer', 'This would be Zip file data buffer...')
+      def('body', 'This would be Zip file data stream')
+      def('nodeFetchResponse', () => mockNodeFetchResponse({
+        status: $.statusCode,
+        buffer: $.buffer,
+        body: $.body,
+        json: $.json,
+      }))
+
+      beforeEach(async function () {
+        client._request.callsFake((url, options) => {
+          return Promise.resolve($.nodeFetchResponse)
+        })
+      })
+
+      context('everything goes well', function () {
+        it('returns data as buffer', async function () {
+          const { statusCode, response, data, errors } = await client.downloadDocuments('docGroupEid123')
+          expect(statusCode).to.eql(200)
+          expect(response).to.deep.eql($.nodeFetchResponse)
+          expect(data).to.eql($.buffer)
+          expect(errors).to.be.undefined
+        })
+
+        it('returns data as stream', async function () {
+          const { statusCode, response, data, errors } = await client.downloadDocuments('docGroupEid123', { dataType: 'stream' })
+          expect(statusCode).to.eql(200)
+          expect(response).to.deep.eql($.nodeFetchResponse)
+          expect(data).to.eql($.body)
+          expect(errors).to.be.undefined
+        })
+      })
+
+      context('unsupported options', function () {
+        it('returns data as buffer', async function () {
+          try {
+            await client.downloadDocuments('docGroupEid123', { dataType: 'json' })
+          } catch (e) {
+            expect(e.message).to.eql('dataType must be one of: stream|buffer')
+          }
+        })
+      })
+
+      context('server 400s with errors array in JSON', function () {
+        const errors = [{ message: 'problem' }]
+        def('statusCode', 400)
+        def('json', { errors })
+
+        it('finds errors and puts them in response', async function () {
+          const { statusCode, errors } = await client.downloadDocuments('docGroupEid123')
+
+          expect(client._request).to.have.been.calledOnce
+          expect(statusCode).to.eql(400)
+          expect(errors).to.eql(errors)
+        })
+      })
+
+      context('server 401s with single error in response', function () {
+        const error = { name: 'AuthorizationError', message: 'problem' }
+        def('statusCode', 401)
+        def('json', error)
+
+        it('finds error and puts it in the response', async function () {
+          const { statusCode, errors } = await client.downloadDocuments('docGroupEid123')
+
+          expect(client._request).to.have.been.calledOnce
+          expect(statusCode).to.eql(401)
+          expect(errors).to.eql([error])
         })
       })
     })
@@ -437,6 +516,105 @@ describe('Anvil API Client', function () {
           } = options
 
           expect(variables).to.eql(variablesReceived)
+          expect(query).to.include(responseQuery)
+          expect(clientOptions).to.eql({ dataType: 'json' })
+        })
+      })
+    })
+
+    describe('generateEtchSignUrl', function () {
+      def('statusCode', 200)
+      beforeEach(async function () {
+        sinon.stub(client, '_request')
+        client._request.callsFake((url, options) => {
+          return Promise.resolve($.nodeFetchResponse)
+        })
+      })
+      afterEach(function () {
+        client._request.restore()
+      })
+
+      context('everything goes well', function () {
+        def('data', {
+          data: {
+            generateEtchSignURL: 'http://www.testing.com',
+          },
+        })
+        def('nodeFetchResponse', () => mockNodeFetchResponse({
+          status: $.statusCode,
+          json: $.data,
+        }))
+
+        it('returns url successfully', async function () {
+          const variables = { clientUserId: 'foo', signerEid: 'bar' }
+          const { statusCode, url, errors } = await client.generateEtchSignUrl({ variables })
+          expect(statusCode).to.eql(200)
+          expect(url).to.be.eql($.data.data.generateEtchSignURL)
+          expect(errors).to.be.undefined
+        })
+      })
+
+      context('generate URL failures', function () {
+        def('data', {
+          data: {},
+        })
+        def('nodeFetchResponse', () => mockNodeFetchResponse({
+          status: $.statusCode,
+          json: $.data,
+        }))
+
+        it('returns undefined url', async function () {
+          const variables = { clientUserId: 'foo', signerEid: 'bar' }
+          const { statusCode, url, errors } = await client.generateEtchSignUrl({ variables })
+          expect(statusCode).to.eql(200)
+          expect(url).to.be.undefined
+          expect(errors).to.be.undefined
+        })
+      })
+    })
+
+    describe('getEtchPacket', function () {
+      def('variables', { eid: 'etchPacketEid123' })
+      beforeEach(function () {
+        sinon.stub(client, 'requestGraphQL')
+      })
+
+      afterEach(function () {
+        client.requestGraphQL.restore()
+      })
+
+      context('no responseQuery specified', function () {
+        it('calls requestGraphQL with default responseQuery', async function () {
+          client.getEtchPacket({ variables: $.variables })
+
+          expect(client.requestGraphQL).to.have.been.calledOnce
+          const [options, clientOptions] = client.requestGraphQL.lastCall.args
+
+          const {
+            query,
+            variables: variablesReceived,
+          } = options
+
+          expect($.variables).to.eql(variablesReceived)
+          expect(query).to.include('documentGroup {')
+          expect(clientOptions).to.eql({ dataType: 'json' })
+        })
+      })
+
+      context('responseQuery specified', function () {
+        it('calls requestGraphQL with overridden responseQuery', async function () {
+          const responseQuery = 'myCustomResponseQuery'
+          client.getEtchPacket({ variables: $.variables, responseQuery })
+
+          expect(client.requestGraphQL).to.have.been.calledOnce
+          const [options, clientOptions] = client.requestGraphQL.lastCall.args
+
+          const {
+            query,
+            variables: variablesReceived,
+          } = options
+
+          expect($.variables).to.eql(variablesReceived)
           expect(query).to.include(responseQuery)
           expect(clientOptions).to.eql({ dataType: 'json' })
         })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -254,7 +254,7 @@ describe('Anvil API Client', function () {
       })
 
       context('unsupported options', function () {
-        it('returns data as buffer', async function () {
+        it('raises appropriate error', async function () {
           try {
             await client.downloadDocuments('docGroupEid123', { dataType: 'json' })
           } catch (e) {


### PR DESCRIPTION
## Description of the change
Having the getEtchPacket method in the client would be extremely helpful for API users to be able to get their etch packet details. Because currently the only time API users are able to get etch packet details is right after they have created it. Also needed for building the signatures API example.

The downloadDocuments method hits our `/api/document-group/:documentGroupEid.zip` route specifically for client API Zip document downloads. Gives an easy abstracted solution for users to download their documents.
 
getEtchPacket use cases:
- get packet data for the `/packet/:packetEid` route in example
- etchPacket documentGroup status checks

downloadDocuments use cases:
- download zip documents button at end of signature workflow
- user doesn't have to deal with finding the downloadZipURL, the client.downloadDocuments() method takes care of that

Added:
- get-etch-packet.js example script
- download-documents.js example script
- docs

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] No previous tests unrelated to the changed code fail in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] At least one reviewer has been requested
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The relevant project board has been selected in Projects to auto-link to this pull request
