### PR TITLE
Add `signatureProvider` to `createEtchPacket` Mutation

### DIFF
--- a/src/graphql/mutations/createEtchPacket.js
+++ b/src/graphql/mutations/createEtchPacket.js
@@ -31,6 +31,7 @@ module.exports = {
       $isTest: Boolean,
       $signatureEmailSubject: String,
       $signatureEmailBody: String,
+      $signatureProvider: String,
       $signaturePageOptions: JSON,
       $signers: [JSON!],
       $data: JSON,
@@ -42,6 +43,7 @@ module.exports = {
         isTest: $isTest,
         signatureEmailSubject: $signatureEmailSubject,
         signatureEmailBody: $signatureEmailBody,
+        signatureProvider: $signatureProvider,
         signaturePageOptions: $signaturePageOptions,
         signers: $signers,
         data: $data


### PR DESCRIPTION
## Description of the change
Allow API user using the Anvil Etch API to specify the signature provider that they would like to use.
Options are `etch` and `docusign`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] No previous tests unrelated to the changed code fail in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] At least one reviewer has been requested
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The relevant project board has been selected in Projects to auto-link to this pull request
