### PR TITLE
Add generatePDF() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ First, you will need to have [uploaded a PDF to Anvil](https://useanvil.com/docs
 An example:
 
 ```js
+const fs = require('fs')
+
+// PDF template you uploaded to Anvil
 const pdfTemplateID = 'kA6Da9CuGqUtc6QiBDRR'
+
 // Your API key from your Anvil organization settings
 const apiKey = '7j2JuUWmN4fGjBxsCltWaybHOEy3UEtt'
 
@@ -91,6 +95,9 @@ const options = {
 }
 const anvilClient = new Anvil({ apiKey })
 const { statusCode, data } = await anvilClient.fillPDF(pdfTemplateID, payload, options)
+
+// Be sure to write the file as raw bytes
+fs.writeFileSync('filled.pdf', data, { encoding: null })
 ```
 
 * `pdfTemplateID` (String) - The id of your PDF template from the Anvil UI

--- a/README.md
+++ b/README.md
@@ -158,7 +158,6 @@ const { statusCode, data } = await anvilClient.generatePDF(payload, options)
 fs.writeFileSync('generated.pdf', data, { encoding: null })
 ```
 
-* `pdfTemplateID` (String) - The id of your PDF template from the Anvil UI
 * `payload` (Object) - The JSON data that will fill the PDF template
   * `title` (String) - _optional_ Set the title encoded into the PDF document
   * `data` (Array of Objects) - The data that generates the PDF. See [the docs](https://useanvil.com/docs/api/generate-pdf#supported-format-of-data) for all supported objects

--- a/README.md
+++ b/README.md
@@ -108,6 +108,62 @@ const { statusCode, data } = await anvilClient.fillPDF(pdfTemplateID, payload, o
   * `errors` (Array of Objects) - Will be present if status >= 400. See Errors
     * `message` (String)
 
+##### generatePDF(payload[, options])
+
+Dynamically generate a new PDF with your JSON data. Useful for agreements, invoices, disclosures, or any other text-heavy documents. This does not require you do anything in the Anvil UI other than setup your API key, just send it data, get a PDF. See [the generate PDF docs](https://useanvil.com/api/generate-pdf) for full details.
+
+An example:
+
+```js
+const fs = require('fs')
+
+// Your API key from your Anvil organization settings
+const apiKey = '7j2JuUWmN4fGjBxsCltWaybHOEy3UEtt'
+
+// JSON data for the new PDF
+const payload = {
+  title: 'Example Invoice',
+  data: [{
+    label: 'Name',
+    content: 'Sally Jones',
+  }, {
+    content: 'Lorem **ipsum** dolor sit _amet_',
+  }, {
+    table: {
+      firstRowHeaders: true,
+      rows: [
+        ['Description', 'Quantity', 'Price'],
+        ['4x Large Widgets', '4', '$40.00'],
+        ['10x Medium Sized Widgets in dark blue', '10', '$100.00'],
+        ['10x Small Widgets in white', '6', '$60.00'],
+      ],
+    },
+  }],
+}
+// The 'options' parameter is optional
+const options = {
+  "dataType": "buffer"
+}
+const anvilClient = new Anvil({ apiKey })
+const { statusCode, data } = await anvilClient.generatePDF(payload, options)
+
+// Be sure to write the file as raw bytes
+fs.writeFileSync('generated.pdf', data, { encoding: null })
+```
+
+* `pdfTemplateID` (String) - The id of your PDF template from the Anvil UI
+* `payload` (Object) - The JSON data that will fill the PDF template
+  * `title` (String) - _optional_ Set the title encoded into the PDF document
+  * `data` (Array of Objects) - The data that generates the PDF. See [the docs](https://useanvil.com/docs/api/generate-pdf#supported-format-of-data) for all supported objects
+    * For example `[{ "label": "Hello World!", "content": "Test" }]`
+* `options` (Object) - _optional_ Any additional options for the request
+  * `dataType` (Enum[String]) - _optional_ Set the type of the `data` value that is returned in the resolved `Promise`. Defaults to `'buffer'`, but `'stream'` is also supported.
+* Returns a `Promise` that resolves to an `Object`
+  * `statusCode` (Number) - the HTTP status code; `200` is success
+  * `data` (Buffer | Stream) - The raw binary data of the filled PDF if success. Will be either a Buffer or a Stream, depending on `dataType` option supplied to the request.
+  * `errors` (Array of Objects) - Will be present if status >= 400. See Errors
+    * `message` (String)
+
 ##### createEtchPacket(options)
 
 Creates an Etch Packet and optionally sends it to the first signer.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ const anvilClient = new Anvil({ apiKey: 'abc123' })
 
 Fills a PDF with your JSON data.
 
-First, you will need to have [uploaded a PDF to Anvil](https://useanvil.com/api/fill-pdf). You can find the PDF template's id on the `API Info` tab of your PDF template's page:
+First, you will need to have [uploaded a PDF to Anvil](https://useanvil.com/docs/api/fill-pdf#creating-a-pdf-template). You can find the PDF template's id on the `API Info` tab of your PDF template's page:
 
 <img width="725" alt="pdf-template-id" src="https://user-images.githubusercontent.com/69169/73693549-4a598280-468b-11ea-81a3-5df4472de8a4.png">
 
@@ -241,13 +241,13 @@ Options for the Anvil Client. Defaults are shown after each option key.
 
 Our API has request rate limits in place. This API client handles `429 Too Many Requests` errors by waiting until it can retry again, then retrying the request. The client attempts to avoid `429` errors by throttling requests after the number of requests within the specified time period has been reached.
 
-See the [Anvil API docs](https://useanvil.com/api/fill-pdf) for more information on the specifics of the rate limits.
+See the [Anvil API docs](https://useanvil.com/docs/api/fill-pdf) for more information on the specifics of the rate limits.
 
 ## API Documentation
 
 Our general API Documentation can be found [here](https://www.useanvil.com/api/). It's the best resource for up-to-date information about our API and its capabilities.
 
-See the [PDF filling API docs](https://useanvil.com/api/fill-pdf) for more information about the `fillPDF` method.
+See the [PDF filling API docs](https://useanvil.com/docs/api/fill-pdf) for more information about the `fillPDF` method.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ const anvilClient = new Anvil({ apiKey: 'abc123' })
 
 ##### fillPDF(pdfTemplateID, payload[, options])
 
-Fills a PDF with your JSON data.
+Fills a PDF template with your JSON data.
 
 First, you will need to have [uploaded a PDF to Anvil](https://useanvil.com/docs/api/fill-pdf#creating-a-pdf-template). You can find the PDF template's id on the `API Info` tab of your PDF template's page:
 

--- a/example/README.md
+++ b/example/README.md
@@ -2,7 +2,7 @@
 
 ## fill-pdf.js script
 
-Calls the fillPDF Anvil endpoint with data specified to fill a PDF with the Anvil API. Outputs the filled PDF in `example/script/fill.output.pdf`
+Calls the fillPDF client function with data specified to fill a PDF with the Anvil API. Outputs the filled PDF in `example/script/fill.output.pdf`
 
 Usage example:
 
@@ -27,10 +27,39 @@ yarn node example/script/fill-pdf.js idabc123 apiKeydef345 ./payload.json && ope
 }
 ```
 
+## generate-pdf.js script
+
+Calls the generatePDF client function with data specified to generate a PDF with the Anvil API. Outputs the generated PDF in `example/script/generate.output.pdf`
+
+Usage example:
+
+```sh
+# Generates a PDF
+yarn node example/script/generate-pdf.js <apiKey> [<inputJSONFile>]
+
+# Generates a PDF with default data, then open the new PDF in preview
+yarn node example/script/generate-pdf.js 5vqCxtgNsA2uzgMH0ps4cyQyadhA2Wdt && open example/script/generate.output.pdf
+
+# Generate a PDF with your payload, then open the new PDF in preview
+yarn node example/script/generate-pdf.js apiKeydef345 ./payload.json && open example/script/generate.output.pdf
+```
+
+`payload.json` is an optional JSON file with the JSON data used to generate the PDF. e.g.
+
+```json
+{
+  "title": "My PDF Title",
+  "data": [{
+    "label": "Hello World!",
+    "content": "Lorem **ipsum** dolor sit _amet_."
+  }]
+}
+```
+
 ## create-etch-packet.js script
 
-Calls the createEtchPacket Anvil endpoint with data specified to generate an Etch Packet with the Anvil API. Returns 
-the status and the generated packet. 
+Calls the createEtchPacket Anvil endpoint with data specified to generate an Etch Packet with the Anvil API. Returns
+the status and the generated packet.
 
 Usage example:
 
@@ -44,7 +73,7 @@ yarn node example/script/create-etch-packet.js WHG3ylq0EE930IR2LZDtgoqgl55M3TwQ 
 
 ## get-etch-packet.js script
 
-Calls the etchPacket Anvil endpoint with the specified Etch packet eid to get the packet details. 
+Calls the etchPacket Anvil endpoint with the specified Etch packet eid to get the packet details.
 
 Usage example:
 

--- a/example/script/fill-pdf.js
+++ b/example/script/fill-pdf.js
@@ -3,10 +3,10 @@
 //
 // Usage example:
 //
-// # Fills a PDF then opens it in preview
+// # Fills a PDF
 // yarn node example/script/fill-pdf.js <pdfTemplateID> <apiKey> <inputJSONFile>
 //
-// # An example
+// # An example that fills then opens the PDF in preview
 // yarn node example/script/fill-pdf.js idabc123 apiKeydef345 ./payload.json && open example/script/fill.output.pdf
 //
 // `payload.json` is a json file with the JSON data used to fill the PDF. e.g.

--- a/example/script/generate-pdf.js
+++ b/example/script/generate-pdf.js
@@ -1,0 +1,114 @@
+// Calls the generatePDF Anvil endpoint with data specified to generate a PDF
+// with the Anvil API. Outputs the generated PDF in `example/script/generate.output.pdf`
+//
+// Usage examples:
+//
+// # Generates a PDF
+// yarn node example/script/generate-pdf.js <apiKey> [<inputJSONFile>]
+//
+// # Generates a PDF with default data, then open the new PDF in preview
+// yarn node example/script/generate-pdf.js 5vqCxtgNsA2uzgMH0ps4cyQyadhA2Wdt && open example/script/generate.output.pdf
+//
+// # Generate a PDF with your payload, then open the new PDF in preview
+// yarn node example/script/generate-pdf.js apiKeydef345 ./payload.json && open example/script/generate.output.pdf
+//
+// `payload.json` is an optional JSON file with the JSON data used to generate the PDF. e.g.
+//
+// {
+//   "title": "My PDF Title",
+//   "data": [{
+//     "label": "Hello World!",
+//     "content": "Lorem **ipsum** dolor sit _amet_."
+//   }]
+// }
+
+const fs = require('fs')
+const path = require('path')
+const Anvil = require('../../src/index')
+const argv = require('yargs')
+  .usage('Usage: $0 apiKey')
+  .option('user-agent', {
+    alias: 'a',
+    type: 'string',
+    description: 'Set the User-Agent on any requests made (default is "Anvil API Client")',
+  })
+  .option('stream', {
+    alias: 's',
+    type: 'boolean',
+    description: 'Return the data as a stream (default is buffer)',
+  })
+  .demandCommand(1).argv
+
+const [apiKey, jsonPath] = argv._
+const returnAStream = argv.stream
+const userAgent = argv['user-agent']
+
+const baseURL = 'https://app.useanvil.com'
+
+const exampleData = jsonPath
+  ? JSON.parse(fs.readFileSync(jsonPath, { encoding: 'utf8' }))
+  : {
+    title: 'Example Invoice',
+    data: [{
+      label: 'Name',
+      content: 'Sally Jones',
+    }, {
+      content: 'Lorem **ipsum** dolor sit _amet_, consectetur adipiscing elit, sed [do eiusmod](https://www.useanvil.com/docs) tempor incididunt ut labore et dolore magna aliqua. Ut placerat orci nulla pellentesque dignissim enim sit amet venenatis.\n\nMi eget mauris pharetra et ultrices neque ornare aenean.\n\n* Sagittis eu volutpat odio facilisis.\n\n* Erat nam at lectus urna.',
+    }, {
+      table: {
+        firstRowHeaders: true,
+        rows: [
+          ['Description', 'Quantity', 'Price'],
+          ['4x Large Widgets', '4', '$40.00'],
+          ['10x Medium Sized Widgets in dark blue', '10', '$100.00'],
+          ['10x Small Widgets in white', '6', '$60.00'],
+        ],
+      },
+    }],
+  }
+
+async function main () {
+  const clientOptions = {
+    baseURL,
+    apiKey,
+  }
+  if (userAgent) {
+    clientOptions.userAgent = userAgent
+  }
+
+  const client = new Anvil(clientOptions)
+
+  const generateOptions = {}
+  if (returnAStream) {
+    generateOptions.dataType = 'stream'
+  }
+
+  const { statusCode, data, errors } = await client.generatePDF(exampleData, generateOptions)
+
+  if (statusCode === 200) {
+    const scriptDir = __dirname
+    const outputFilePath = path.join(scriptDir, 'generate.output.pdf')
+
+    if (returnAStream) {
+      const writeStream = fs.createWriteStream(outputFilePath, { encoding: null })
+      await new Promise((resolve, reject) => {
+        data.pipe(writeStream)
+        data.on('error', reject)
+        writeStream.on('finish', resolve)
+      })
+    } else {
+      fs.writeFileSync(outputFilePath, data, { encoding: null })
+    }
+  } else {
+    console.log(statusCode, JSON.stringify(errors || data, null, 2))
+  }
+}
+
+main()
+  .then(() => {
+    process.exit(0)
+  })
+  .catch((err) => {
+    console.log(err.stack || err.message)
+    process.exit(1)
+  })

--- a/src/index.js
+++ b/src/index.js
@@ -113,6 +113,29 @@ class Anvil {
     )
   }
 
+  generatePDF (payload, clientOptions = {}) {
+    const supportedDataTypes = [DATA_TYPE_STREAM, DATA_TYPE_BUFFER]
+    const { dataType = DATA_TYPE_BUFFER } = clientOptions
+    if (dataType && !supportedDataTypes.includes(dataType)) {
+      throw new Error(`dataType must be one of: ${supportedDataTypes.join('|')}`)
+    }
+
+    return this.requestREST(
+      '/api/v1/generate-pdf',
+      {
+        method: 'POST',
+        body: JSON.stringify(payload),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+      {
+        ...clientOptions,
+        dataType,
+      },
+    )
+  }
+
   createEtchPacket ({ variables, responseQuery, mutation }) {
     return this.requestGraphQL(
       {


### PR DESCRIPTION
This adds `client.generatePDF(payload, options)` to the client for the `/api/v1/generate-pdf` REST endpoint.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
