### PR TITLE
allow null values for forge update mutation

### DIFF
--- a/src/validation.js
+++ b/src/validation.js
@@ -8,7 +8,7 @@ function isFile (value) {
 }
 
 function graphQLUploadSchemaIsValid (schema, parent, key) {
-  if (typeof schema === 'undefined') {
+  if (schema == null) { //schema is null or undefined
     return true
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -421,7 +421,7 @@ describe('Anvil API Client', function () {
         })
 
         describe('schema is good', function () {
-          const query = { foo: 'bar' }
+          const query = { foo: 'bar', baz: null }
           const clientOptions = { yo: 'mtvRaps' }
 
           afterEach(function () {


### PR DESCRIPTION
default forge config has null values on finishPage.  To
edit forge config without changing finishPage, we need to allow
those null values

## Description of the change

Description here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes #1

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] No previous tests unrelated to the changed code fail in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] At least one reviewer has been requested
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The relevant project board has been selected in Projects to auto-link to this pull request
