### PR TITLE
fix a bug that can happen when parsing errors in node client

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -118,7 +118,6 @@ describe('Anvil API Client', function () {
         clientOptions = {
           dataType: 'json',
         }
-        data = { result: 'ok' }
 
         client._request.callsFake((url, options) => {
           return Promise.resolve(


### PR DESCRIPTION
## Description of the change

Fixes a bug when handling certain kinds of API response errors...the response is not always nice, clean JSON, and that would blow up the JSON parsing attempt.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes #1

## Checklists

### Development

- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] No previous tests unrelated to the changed code fail in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] At least one reviewer has been requested
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The relevant project board has been selected in Projects to auto-link to this pull request
