### PR TITLE
Allow passing ratelimit options to the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,9 @@ Options for the Anvil Client. Defaults are shown after each option key.
 
 ```js
 {
-  apiKey: <your_api_key> // Required. Your API key from your Anvil organization settings
+  apiKey: <your_api_key>, // Required. Your API key from your Anvil  organization settings
+  requestLimit: 40, // Set to 2 when using the development API key
+  requestLimitMS: 1000,
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,11 @@ const DATA_TYPE_JSON = 'json'
 const defaultOptions = {
   baseURL: 'https://app.useanvil.com',
   userAgent: `${description}/${version}`,
+
+  // Production apiKey rate limits: 40 per second
+  // Development apiKey rate limits: 2 per second
+  requestLimit: 40,
+  requestLimitMS: 1000,
 }
 
 const failBufferMS = 50
@@ -69,9 +74,8 @@ class Anvil {
       ? `Bearer ${Buffer.from(accessToken, 'ascii').toString('base64')}`
       : `Basic ${Buffer.from(`${apiKey}:`, 'ascii').toString('base64')}`
 
-    // Production apiKey rate limits: 200 in 5 seconds
-    this.requestLimit = 200
-    this.requestLimitMS = 5000
+    this.requestLimit = this.options.requestLimit
+    this.requestLimitMS = this.options.requestLimitMS
     this.limiter = new RateLimiter(this.requestLimit, this.requestLimitMS, true)
   }
 


### PR DESCRIPTION
The dev limits are much lower than the prod limits. Allow a mechanism to pass the dev limits to avoid retries.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
