### PR TITLE
[security] update lockfile to fix security vuln

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2769,9 +2769,9 @@ y18n@^4.0.0:
   integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
 
 y18n@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.1.tgz#1ad2a7eddfa8bce7caa2e1f6b5da96c39d99d571"
-  integrity sha512-/jJ831jEs4vGDbYPQp4yGKDYPSCCEQ45uZWJHE1AoYBzqdZi8+LDWas0z4HrmJXmKdpFsTiowSHXdxyFhpmdMg==
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
+  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
 
 yargs-parser@13.1.2, yargs-parser@^13.1.2:
   version "13.1.2"


### PR DESCRIPTION
## Description of the change

Not sure why dependabot only fixed the 4.X requirements, but the 5.x one is also vulnerable, so this updates that.

https://github.com/anvilco/node-anvil/security/dependabot/yarn.lock/y18n/open

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] No previous tests unrelated to the changed code fail in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] At least one reviewer has been requested
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The relevant project board has been selected in Projects to auto-link to this pull request
