### PR TITLE
Adjust rate limiting dynamically based on API response

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ Options for the Anvil Client. Defaults are shown after each option key.
 ```js
 {
   apiKey: <your_api_key>, // Required. Your API key from your Anvil  organization settings
+  // If you set the keyType, you do not need to set the requestLimit and requestLimitMS values, and vice-versa
+  keyType: 'development', // Used to determine the request limiting values to use
   requestLimit: 40, // Set to 2 when using the development API key
   requestLimitMS: 1000,
 }

--- a/README.md
+++ b/README.md
@@ -240,16 +240,12 @@ Options for the Anvil Client. Defaults are shown after each option key.
 ```js
 {
   apiKey: <your_api_key>, // Required. Your API key from your Anvil  organization settings
-  // If you set the keyType, you do not need to set the requestLimit and requestLimitMS values, and vice-versa
-  keyType: 'development', // Used to determine the request limiting values to use
-  requestLimit: 40, // Set to 2 when using the development API key
-  requestLimitMS: 1000,
 }
 ```
 
 ### Rate Limits
 
-Our API has request rate limits in place. This API client handles `429 Too Many Requests` errors by waiting until it can retry again, then retrying the request. The client attempts to avoid `429` errors by throttling requests after the number of requests within the specified time period has been reached.
+Our API has request rate limits in place. The initial request made by this client will parse the limits for your account from the response headers, and then handle the throttling of subsequent requests for you automatically. In the event that this client still receives a `429 Too Many Requests` error response, it will wait the specified duration then retry the request. The client attempts to avoid `429` errors by throttling requests after the number of requests within the specified time period has been reached.
 
 See the [Anvil API docs](https://useanvil.com/docs/api/fill-pdf) for more information on the specifics of the rate limits.
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "abort-controller": "^3.0.0",
     "extract-files": "^6",
     "form-data": "^3.0.0",
-    "limiter": "^1.1.5",
+    "limiter": "^2.1.0",
     "node-fetch": "^2.6.0"
   },
   "resolutions": {

--- a/src/index.js
+++ b/src/index.js
@@ -57,16 +57,10 @@ class Anvil {
   constructor (options) {
     if (!options) throw new Error('options are required')
 
-    // Production apiKey rate limits: 40 per second
-    // Development apiKey rate limits: 2 per second
-    const limitOptions = {
-      requestLimit: options.keyType === 'development' ? 2 : 40,
-      requestLimitMS: 1000,
-    }
-
     this.options = {
       ...defaultOptions,
-      ...limitOptions,
+      requestLimit: 1,
+      requestLimitMS: 1000,
       ...options,
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -43,11 +43,6 @@ const DATA_TYPE_JSON = 'json'
 const defaultOptions = {
   baseURL: 'https://app.useanvil.com',
   userAgent: `${description}/${version}`,
-
-  // Production apiKey rate limits: 40 per second
-  // Development apiKey rate limits: 2 per second
-  requestLimit: 40,
-  requestLimitMS: 1000,
 }
 
 const failBufferMS = 50
@@ -62,8 +57,16 @@ class Anvil {
   constructor (options) {
     if (!options) throw new Error('options are required')
 
+    // Production apiKey rate limits: 40 per second
+    // Development apiKey rate limits: 2 per second
+    const limitOptions = {
+      requestLimit: options.keyType === 'development' ? 2 : 40,
+      requestLimitMS: 1000,
+    }
+
     this.options = {
       ...defaultOptions,
+      ...limitOptions,
       ...options,
     }
 
@@ -74,9 +77,39 @@ class Anvil {
       ? `Bearer ${Buffer.from(accessToken, 'ascii').toString('base64')}`
       : `Basic ${Buffer.from(`${apiKey}:`, 'ascii').toString('base64')}`
 
-    this.requestLimit = this.options.requestLimit
-    this.requestLimitMS = this.options.requestLimitMS
-    this.limiter = new RateLimiter(this.requestLimit, this.requestLimitMS, true)
+    this._setRateLimiter({ tokens: this.options.requestLimit, intervalMs: this.options.requestLimitMS })
+  }
+
+  _setRateLimiter ({ tokens, intervalMs }) {
+    if (
+      // Both must be truthy
+      !(tokens && intervalMs) ||
+      // Things should not be the same as they already are
+      (this.limitTokens === tokens && this.limitIntervalMs === intervalMs)
+    ) {
+      return
+    }
+
+    const newLimiter = new RateLimiter({ tokensPerInterval: tokens, interval: intervalMs })
+
+    // If we already had a limiter, let's try to pick up where it left off
+    if (this.limiter) {
+      const tokensInUse = Math.max(
+        // getTokensRemaining() can return a decimal, so we round it down
+        // so as to be conservative about potentially hitting the API again
+        this.limitTokens - Math.floor(this.limiter.getTokensRemaining()),
+        0,
+      )
+      const tokensToRemove = Math.min(tokens, tokensInUse)
+      if (tokensToRemove) {
+        newLimiter.tryRemoveTokens(tokensToRemove)
+      }
+      delete this.limiter
+    }
+
+    this.limitTokens = tokens
+    this.limitIntervalMs = intervalMs
+    this.limiter = newLimiter
   }
 
   /**
@@ -342,6 +375,15 @@ class Anvil {
     return this._throttle(async (retry) => {
       const { dataType, debug } = clientOptions
       const response = await retryableRequestFn()
+
+      if (!this.hasSetLimiter) {
+        this.hasSetLimiter = true
+        const tokens = parseInt(response.headers.get('x-ratelimit-limit'))
+        const intervalMs = parseInt(response.headers.get('x-ratelimit-interval-ms'))
+
+        this._setRateLimiter({ tokens, intervalMs })
+      }
+
       const { status: statusCode, statusText } = response
 
       if (statusCode >= 300) {
@@ -429,24 +471,17 @@ class Anvil {
     )
   }
 
-  _throttle (fn) {
-    return new Promise((resolve, reject) => {
-      this.limiter.removeTokens(1, async (err, remainingRequests) => {
-        if (err) reject(err)
-        if (remainingRequests < 1) {
-          await sleep(this.requestLimitMS + failBufferMS)
-        }
-        const retry = async (ms) => {
-          await sleep(ms)
-          return this._throttle(fn)
-        }
-        try {
-          resolve(await fn(retry))
-        } catch (e) {
-          reject(e)
-        }
-      })
-    })
+  async _throttle (fn) {
+    const remainingRequests = await this.limiter.removeTokens(1)
+    if (remainingRequests < 1) {
+      await sleep(this.requestLimitMS + failBufferMS)
+    }
+    const retry = async (ms) => {
+      await sleep(ms)
+      return this._throttle(fn)
+    }
+
+    return fn(retry)
   }
 
   static _prepareGraphQLBase64 (data, options = {}) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,8 +1,10 @@
 const fs = require('fs')
 const path = require('path')
 
+const { RateLimiter } = require('limiter')
 const FormData = require('form-data')
 const AbortSignal = require('abort-controller').AbortSignal
+
 const Anvil = require('../src/index')
 
 const assetsDir = path.join(__dirname, 'assets')
@@ -139,6 +141,41 @@ describe('Anvil API Client', function () {
         const result = await client.requestREST('/non-existing-endpoint', options, clientOptions)
         expect(result.statusCode).to.eql(404)
         expect(result.errors).to.eql(['Not Found'])
+      })
+
+      it('sets the rate limiter from the response headers', async function () {
+        // Originally, these are true
+        expect(client.hasSetLimiterFromResponse).to.eql(false)
+        expect(client.limiterSettingInProgress).to.eql(false)
+        expect(client.rateLimiterSetupPromise).to.be.an.instanceof(Promise)
+        expect(client.limitTokens).to.eql(1)
+        expect(client.limitIntervalMs).to.eql(1000)
+        expect(client.limiter).to.be.an.instanceof(RateLimiter)
+
+        client._request.callsFake((url, options) => {
+          return Promise.resolve(
+            mockNodeFetchResponse({
+              status: 200,
+              json: data,
+              headers: {
+                'x-ratelimit-limit': 42,
+                'x-ratelimit-interval-ms': 4200,
+              },
+            }),
+          )
+        })
+
+        const result = await client.requestREST('/test', options, clientOptions)
+
+        // Afterwards, these are true
+        expect(client._request).to.have.been.calledOnce
+        expect(result.statusCode).to.eql(200)
+        expect(result.data).to.eql(data)
+
+        expect(client.hasSetLimiterFromResponse).to.eql(true)
+        expect(client.limitTokens).to.eql(42)
+        expect(client.limitIntervalMs).to.eql(4200)
+        expect(client.limiter).to.be.an.instanceof(RateLimiter)
       })
 
       it('retries when a 429 response', async function () {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,7 +13,10 @@ function mockNodeFetchResponse (options = {}) {
     statusText,
     json,
     buffer,
-    headers,
+    headers = {
+      'x-ratelimit-limit': 1,
+      'x-ratelimit-interval-ms': 1000,
+    },
     body,
   } = options
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1583,6 +1583,11 @@ just-extend@^4.0.2:
   resolved "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
   integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
 
+just-performance@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/just-performance/-/just-performance-4.3.0.tgz#cc2bc8c9227f09e97b6b1df4cd0de2df7ae16db1"
+  integrity sha512-L7RjvtJsL0QO8xFs5wEoDDzzJwoiowRw6Rn/GnvldlchS2JQr9wFYPiwZcDfrbbujEKqKN0tvENdbjXdYhDp5Q==
+
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
@@ -1605,10 +1610,12 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-limiter@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz#8f92a25b3b16c6131293a0cc834b4a838a2aa7c2"
-  integrity sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==
+limiter@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/limiter/-/limiter-2.1.0.tgz#d38d7c5b63729bb84fb0c4d8594b7e955a5182a2"
+  integrity sha512-361TYz6iay6n+9KvUUImqdLuFigK+K79qrUtBsXhJTLdH4rIt/r1y8r1iozwh8KbZNpujbFTSh74mJ7bwbAMOw==
+  dependencies:
+    just-performance "4.3.0"
 
 load-json-file@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description of the change

So that the rate limiting in the Node Client tries to do a good job, I've done 2 things here:
~~1. Allow the User to pass a `keyType` option to the constructor that will determine what rate limiting options it will try to do~~
2. Leverage the response headers from the server to adjust the rate limiter if necessary, so in the end, the User doesn't really need to know/do anything.

This 2nd one above deserves some discussion/thought:
- It basically chooses the first request as a "golden request" to go first, and then sets the Rate Limiter for the Client based on the information the Server gives back in the response headers.
- While this "golden request" is in flight, any other requests that come through will all have to wait for it to complete...but then they will all go as fast at the Rate Limiter will let them once the "golden request" has done its thing.
- This only happens once per instance of a Client.
- In my experimentation, it appears to lead to comparable-if-not-better average performance.

An additional benefit of this is that if we ever change our rate limits, or want to change them per-client/api key, the code will "just work"™️ for them in the future.

~~If we like this, perhaps I should actually rip all the stuff where the User can even specify rate limit stuff (`requestLimit`, `requestLimitMS`, `keyType`), and let it all come from the server?~~
☝️  we did this

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Relates to https://github.com/anvilco/anvil/issues/2220

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] No previous tests unrelated to the changed code fail in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] At least one reviewer has been requested
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The relevant project board has been selected in Projects to auto-link to this pull request
