### PR TITLE
no more dynamic requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.15.1]
+- Non-dynamic `require`s in GraphQL modules.
+- Dependency updates.
+
 ## [v2.15.0]
 - Assert that the `filename` property is (likely) there [`312`](https://github.com/anvilco/node-anvil/pull/312)
 - Dependency updates.

--- a/src/graphql/mutations/index.js
+++ b/src/graphql/mutations/index.js
@@ -1,11 +1,6 @@
-const fs = require('fs')
-
-const IGNORE_FILES = ['index.js']
-
-module.exports = fs.readdirSync(__dirname)
-  .filter((fileName) => (fileName.endsWith('.js') && !fileName.startsWith('.') && !IGNORE_FILES.includes(fileName)))
-  .reduce((acc, fileName) => {
-    const mutationName = fileName.slice(0, fileName.length - 3)
-    acc[mutationName] = require(`./${mutationName}`)
-    return acc
-  }, {})
+module.exports = {
+  createEtchPacket: require('./createEtchPacket'),
+  forgeSubmit: require('./forgeSubmit'),
+  generateEtchSignUrl: require('./generateEtchSignUrl'),
+  removeWeldData: require('./removeWeldData'),
+}

--- a/src/graphql/queries/index.js
+++ b/src/graphql/queries/index.js
@@ -1,11 +1,3 @@
-const fs = require('fs')
-
-const IGNORE_FILES = ['index.js']
-
-module.exports = fs.readdirSync(__dirname)
-  .filter((fileName) => (fileName.endsWith('.js') && !fileName.startsWith('.') && !IGNORE_FILES.includes(fileName)))
-  .reduce((acc, fileName) => {
-    const queryName = fileName.slice(0, fileName.length - 3)
-    acc[queryName] = require(`./${queryName}`)
-    return acc
-  }, {})
+module.exports = {
+  etchPacket: require('./etchPacket'),
+}


### PR DESCRIPTION
## Description of the change

Client states:
> We've run into an issue with the anvil nodejs sdk.  @anvilco/anvil.  Specifically src/graphql/mutations/index.js and src/graphql/queries/index.js use runtime logic to calculate require() calls.  This breaks bundlers (we're using esbuild) as they don't know about those files to inline them.  I'm working on a manual patch for the anvil SDK now to import these statically, but it'd be nice to not have to maintain that patch.

This is because we were dynamically reading the directory and requiring all the files. That's neat-o, but not good for code analyzers like bundlers. Get rid of that.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes https://github.com/anvilco/node-anvil/issues/309

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] No previous tests unrelated to the changed code fail in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] At least one reviewer has been requested
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The relevant project board has been selected in Projects to auto-link to this pull request
