### PR TITLE
Fix exports for ESM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.0.1]
+- Fix "double-default" ESM exports, but also leave for backwards compatibility. https://github.com/anvilco/node-anvil/issues/354
+
 ## [v3.0.0]
 - BREAKING: Drop support for `Node 12`.
 - BREAKING: Changed to `ES6` style exports.

--- a/index.js
+++ b/index.js
@@ -2,4 +2,6 @@ const Dist = require('./dist')
 
 // This file is mainly just for cleaning up the exports to be intuitive/commonjs
 module.exports = Dist.default
+// This is here just for backwards compatibilty. Should be removed at next
+// major verison to avoid a breaking change
 module.exports.default = Dist.default

--- a/index.js
+++ b/index.js
@@ -1,2 +1,5 @@
+const Dist = require('./dist')
+
 // This file is mainly just for cleaning up the exports to be intuitive/commonjs
-module.exports = require('./dist')
+module.exports = Dist.default
+module.exports.default = Dist.default

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvilco/anvil",
-  "version": "3.0.1-beta.0",
+  "version": "3.0.1",
   "description": "Anvil API Client",
   "author": "Anvil Foundry Inc.",
   "homepage": "https://github.com/anvilco/node-anvil#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvilco/anvil",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Anvil API Client",
   "author": "Anvil Foundry Inc.",
   "homepage": "https://github.com/anvilco/node-anvil#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvilco/anvil",
-  "version": "3.0.1",
+  "version": "3.0.1-beta.0",
   "description": "Anvil API Client",
   "author": "Anvil Foundry Inc.",
   "homepage": "https://github.com/anvilco/node-anvil#readme",


### PR DESCRIPTION
## Description of the change

Fix exports for ESM.
I am debating:
1. Whether to still include the nested `default` export for backwards compat
2. and/or whether to bump the version by `major`, `minor`, or `patch` for the change. Sorta depends on `1.` above.

Here is an output showing the result of
```js
// When consuming project is CJS
const anvil = require('@anvilco/anvil')
console.log({
  anvil,
})
```
and
```js
// When consuming project is ESM
import anvil, * as anvilModule  from '@anvilco/anvil'
import { default as anvilDefault } from '@anvilco/anvil'
console.log({
  anvil,
  anvilDefault,
  anvilModule,
})
```
![image](https://github.com/anvilco/node-anvil/assets/2524009/2f114e21-55c0-4ed4-b697-c8f31595c269)


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes https://github.com/anvilco/node-anvil/issues/354

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] No previous tests unrelated to the changed code fail in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] At least one reviewer has been requested
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The relevant project board has been selected in Projects to auto-link to this pull request
