### PR TITLE
Add .anvil/marketing.yml for marketing-site language pages

### DIFF
--- a/.anvil/marketing.yml
+++ b/.anvil/marketing.yml
@@ -1,5 +1,7 @@
 packageManagerInstall:
   - npm install @anvilco/anvil
+  - yarn add @anvilco/anvil
+  - pnpm add @anvilco/anvil
 languages:
   - key: javascript
     label: JavaScript

--- a/.anvil/marketing.yml
+++ b/.anvil/marketing.yml
@@ -1,14 +1,7 @@
-products:
-  - generate
-  - fill
-  - sign
-packageManagerInstall: npm install @anvilco/anvil
+packageManagerInstall:
+  - npm install @anvilco/anvil
 languages:
   - key: javascript
     label: JavaScript
-    examples:
-      generate: example/script/generate-markdown-pdf.js
-      fill: example/script/fill-pdf.js
-      sign: example/script/create-etch-packet.js
   - key: typescript
     label: TypeScript

--- a/.anvil/marketing.yml
+++ b/.anvil/marketing.yml
@@ -1,0 +1,21 @@
+# Language declaration for anvilco/marketing-site. Read at build time to source
+# the JavaScript and TypeScript SDK pages from this repo (one repo serves both).
+# `supported` is omitted so it derives from repo visibility (public = live).
+# TypeScript has no separate example files here, so its code samples fall back
+# to the marketing-site's committed content until .ts examples are added.
+products:
+  - generate
+  - fill
+  - sign
+packageManagerInstall: npm install @anvilco/anvil
+languages:
+  - key: javascript
+    label: JavaScript
+    slug: javascript
+    examples:
+      generate: example/script/generate-markdown-pdf.js
+      fill: example/script/fill-pdf.js
+      sign: example/script/create-etch-packet.js
+  - key: typescript
+    label: TypeScript
+    slug: typescript

--- a/.anvil/marketing.yml
+++ b/.anvil/marketing.yml
@@ -1,8 +1,3 @@
-# Language declaration for anvilco/marketing-site. Read at build time to source
-# the JavaScript and TypeScript SDK pages from this repo (one repo serves both).
-# `supported` is omitted so it derives from repo visibility (public = live).
-# TypeScript has no separate example files here, so its code samples fall back
-# to the marketing-site's committed content until .ts examples are added.
 products:
   - generate
   - fill
@@ -11,11 +6,9 @@ packageManagerInstall: npm install @anvilco/anvil
 languages:
   - key: javascript
     label: JavaScript
-    slug: javascript
     examples:
       generate: example/script/generate-markdown-pdf.js
       fill: example/script/fill-pdf.js
       sign: example/script/create-etch-packet.js
   - key: typescript
     label: TypeScript
-    slug: typescript

--- a/.anvil/marketing.yml
+++ b/.anvil/marketing.yml
@@ -2,6 +2,7 @@ packageManagerInstall:
   - npm install @anvilco/anvil
   - yarn add @anvilco/anvil
   - pnpm add @anvilco/anvil
+  - bun add @anvilco/anvil
 languages:
   - key: javascript
     label: JavaScript


### PR DESCRIPTION
Adds `.anvil/marketing.yml` so anvilco/marketing-site sources this repo's JavaScript and TypeScript SDK pages at build time (language identity, install command, products, and per-product example paths) instead of hardcoding them in the marketing site.

One repo serves both languages, so the block declares `javascript` and `typescript`. `supported` is omitted so the marketing site derives live/coming-soon from this repo's visibility. JavaScript maps to the `example/script/*.js` files; TypeScript has no separate `.ts` examples here, so its samples fall back to the marketing site's committed content until `.ts` examples are added.

Related to anvilco/marketing-site#3505.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/anvilco/codesmith/node-anvil/pr/506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788559156&installation_model_id=8728&pr_number=506&repository=anvilco%2Fnode-anvil&return_to=https%3A%2F%2Fgithub.com%2Fanvilco%2Fnode-anvil%2Fpull%2F506&signature=ce8ea2d9331ac0474ac59f05a99762fed76596273b7cbb596ab05b4efdaa1cb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->