### PR TITLE
Add canonical examples/ scripts for marketing SDK pages

### DIFF
--- a/examples/create-etch-packet.js
+++ b/examples/create-etch-packet.js
@@ -1,0 +1,46 @@
+// Create an e-sign packet with the Anvil API.
+// https://www.useanvil.com/docs/api/e-signatures
+//
+// Run: ANVIL_API_KEY=<key> node examples/create-etch-packet.js <your.email@example.com>
+const Anvil = require('@anvilco/anvil')
+
+const pdfTemplateID = '05xXsZko33JIO6aq5Pnr'
+const signerName = 'Testy Signer'
+const signerEmail = process.argv[2]
+const anvilClient = new Anvil({ apiKey: process.env.ANVIL_API_KEY })
+
+if (!signerEmail) {
+  console.log('Usage: node examples/create-etch-packet.js <your.email@example.com>')
+  process.exit(1)
+}
+
+const variables = {
+  isDraft: false,
+  // Test packets use development signatures and do not count toward billing.
+  isTest: true,
+  name: `Test Docs - ${signerName}`,
+  files: [{ id: 'sampleTemplate', castEid: pdfTemplateID }],
+  data: {
+    payloads: {
+      sampleTemplate: { data: { name: signerName, email: signerEmail } },
+    },
+  },
+  signers: [{
+    id: 'signer1',
+    name: signerName,
+    email: signerEmail,
+    signerType: 'email',
+    fields: [{ fileId: 'sampleTemplate', fieldId: 'signature' }],
+  }],
+}
+
+async function main () {
+  const { data, errors } = await anvilClient.createEtchPacket({ variables })
+  if (errors) {
+    console.log('Errors:', JSON.stringify(errors, null, 2))
+    return
+  }
+  console.log('Packet created:', data.data.createEtchPacket.detailsURL)
+}
+
+main()

--- a/examples/create-etch-packet.ts
+++ b/examples/create-etch-packet.ts
@@ -1,0 +1,46 @@
+// Create an e-sign packet with the Anvil API.
+// https://www.useanvil.com/docs/api/e-signatures
+//
+// Run: ANVIL_API_KEY=<key> yarn ts-node examples/create-etch-packet.ts <your.email@example.com>
+import Anvil, { GraphQLResponse } from '@anvilco/anvil'
+
+const pdfTemplateID = '05xXsZko33JIO6aq5Pnr'
+const signerName = 'Testy Signer'
+const signerEmail = process.argv[2] ?? ''
+const anvilClient = new Anvil({ apiKey: process.env['ANVIL_API_KEY'] ?? '' })
+
+if (!signerEmail) {
+  console.log('Usage: yarn ts-node examples/create-etch-packet.ts <your.email@example.com>')
+  process.exit(1)
+}
+
+const variables = {
+  isDraft: false,
+  // Test packets use development signatures and do not count toward billing.
+  isTest: true,
+  name: `Test Docs - ${signerName}`,
+  files: [{ id: 'sampleTemplate', castEid: pdfTemplateID }],
+  data: {
+    payloads: {
+      sampleTemplate: { data: { name: signerName, email: signerEmail } },
+    },
+  },
+  signers: [{
+    id: 'signer1',
+    name: signerName,
+    email: signerEmail,
+    signerType: 'email',
+    fields: [{ fileId: 'sampleTemplate', fieldId: 'signature' }],
+  }],
+}
+
+async function main () {
+  const { data, errors }: GraphQLResponse = await anvilClient.createEtchPacket({ variables })
+  if (errors) {
+    console.log('Errors:', JSON.stringify(errors, null, 2))
+    return
+  }
+  console.log('Packet created:', data?.data['createEtchPacket'].detailsURL)
+}
+
+main()

--- a/examples/fill.js
+++ b/examples/fill.js
@@ -1,0 +1,35 @@
+// Fill a PDF template with the Anvil API.
+// https://www.useanvil.com/docs/api/fill-pdf
+//
+// Run: ANVIL_API_KEY=<key> node examples/fill.js
+const fs = require('fs')
+const Anvil = require('@anvilco/anvil')
+
+// Sample template available to anyone; make your own at
+// https://www.useanvil.com/help/tutorials/set-up-a-pdf-template
+const pdfTemplateID = '05xXsZko33JIO6aq5Pnr'
+const anvilClient = new Anvil({ apiKey: process.env.ANVIL_API_KEY })
+
+const exampleData = {
+  title: 'My PDF Title',
+  fontSize: 10,
+  textColor: '#333333',
+  data: {
+    shortText: 'Hello World!',
+    name: { firstName: 'Robin', lastName: 'Smith' },
+    email: 'robin@example.com',
+  },
+}
+
+async function main () {
+  const { statusCode, data, errors } = await anvilClient.fillPDF(pdfTemplateID, exampleData)
+  if (statusCode !== 200) {
+    console.log('Errors:', JSON.stringify(errors, null, 2))
+    return
+  }
+  // `data` is the filled PDF binary; save with no encoding or the file corrupts.
+  fs.writeFileSync('fill-output.pdf', data, { encoding: null })
+  console.log('Saved fill-output.pdf')
+}
+
+main()

--- a/examples/fill.ts
+++ b/examples/fill.ts
@@ -1,0 +1,35 @@
+// Fill a PDF template with the Anvil API.
+// https://www.useanvil.com/docs/api/fill-pdf
+//
+// Run: ANVIL_API_KEY=<key> yarn ts-node examples/fill.ts
+import fs from 'fs'
+import Anvil from '@anvilco/anvil'
+
+// Sample template available to anyone; make your own at
+// https://www.useanvil.com/help/tutorials/set-up-a-pdf-template
+const pdfTemplateID = '05xXsZko33JIO6aq5Pnr'
+const anvilClient = new Anvil({ apiKey: process.env['ANVIL_API_KEY'] ?? '' })
+
+const exampleData = {
+  title: 'My PDF Title',
+  fontSize: 10,
+  textColor: '#333333',
+  data: {
+    shortText: 'Hello World!',
+    name: { firstName: 'Robin', lastName: 'Smith' },
+    email: 'robin@example.com',
+  },
+}
+
+async function main () {
+  const { statusCode, data, errors } = await anvilClient.fillPDF(pdfTemplateID, exampleData)
+  if (statusCode !== 200 || !data) {
+    console.log('Errors:', JSON.stringify(errors, null, 2))
+    return
+  }
+  // `data` is the filled PDF binary; save with no encoding or the file corrupts.
+  fs.writeFileSync('fill-output.pdf', data, { encoding: null })
+  console.log('Saved fill-output.pdf')
+}
+
+main()

--- a/examples/generate-html.js
+++ b/examples/generate-html.js
@@ -1,0 +1,35 @@
+// Generate a PDF from HTML and CSS with the Anvil API.
+// https://www.useanvil.com/docs/api/generate-pdf
+//
+// Run: ANVIL_API_KEY=<key> node examples/generate-html.js
+const fs = require('fs')
+const Anvil = require('@anvilco/anvil')
+
+const anvilClient = new Anvil({ apiKey: process.env.ANVIL_API_KEY })
+
+const exampleData = {
+  title: 'Example HTML to PDF',
+  type: 'html',
+  data: {
+    html: `
+      <h1>What is Lorem Ipsum?</h1>
+      <p>
+        Lorem Ipsum is simply dummy text of the printing and typesetting
+        industry, and has been the standard ever since the <strong>1500s</strong>.
+      </p>
+    `,
+    css: 'body { font-size: 14px; color: #171717; }',
+  },
+}
+
+async function main () {
+  const { statusCode, data, errors } = await anvilClient.generatePDF(exampleData)
+  if (statusCode !== 200) {
+    console.log('Errors:', JSON.stringify(errors, null, 2))
+    return
+  }
+  fs.writeFileSync('generate-html-output.pdf', data, { encoding: null })
+  console.log('Saved generate-html-output.pdf')
+}
+
+main()

--- a/examples/generate-html.ts
+++ b/examples/generate-html.ts
@@ -1,0 +1,35 @@
+// Generate a PDF from HTML and CSS with the Anvil API.
+// https://www.useanvil.com/docs/api/generate-pdf
+//
+// Run: ANVIL_API_KEY=<key> yarn ts-node examples/generate-html.ts
+import fs from 'fs'
+import Anvil from '@anvilco/anvil'
+
+const anvilClient = new Anvil({ apiKey: process.env['ANVIL_API_KEY'] ?? '' })
+
+const exampleData = {
+  title: 'Example HTML to PDF',
+  type: 'html',
+  data: {
+    html: `
+      <h1>What is Lorem Ipsum?</h1>
+      <p>
+        Lorem Ipsum is simply dummy text of the printing and typesetting
+        industry, and has been the standard ever since the <strong>1500s</strong>.
+      </p>
+    `,
+    css: 'body { font-size: 14px; color: #171717; }',
+  },
+}
+
+async function main () {
+  const { statusCode, data, errors } = await anvilClient.generatePDF(exampleData)
+  if (statusCode !== 200 || !data) {
+    console.log('Errors:', JSON.stringify(errors, null, 2))
+    return
+  }
+  fs.writeFileSync('generate-html-output.pdf', data, { encoding: null })
+  console.log('Saved generate-html-output.pdf')
+}
+
+main()

--- a/examples/generate-markdown.js
+++ b/examples/generate-markdown.js
@@ -1,0 +1,39 @@
+// Generate a PDF from Markdown with the Anvil API.
+// https://www.useanvil.com/docs/api/generate-pdf
+//
+// Run: ANVIL_API_KEY=<key> node examples/generate-markdown.js
+const fs = require('fs')
+const Anvil = require('@anvilco/anvil')
+
+const anvilClient = new Anvil({ apiKey: process.env.ANVIL_API_KEY })
+
+const exampleData = {
+  title: 'Example Invoice',
+  data: [{
+    label: 'Name',
+    content: 'Sally Jones',
+  }, {
+    content: 'Lorem **ipsum** dolor sit _amet_, consectetur adipiscing elit.',
+  }, {
+    table: {
+      firstRowHeaders: true,
+      rows: [
+        ['Description', 'Quantity', 'Price'],
+        ['4x Large Widgets', '4', '$40.00'],
+        ['10x Medium Widgets', '10', '$100.00'],
+      ],
+    },
+  }],
+}
+
+async function main () {
+  const { statusCode, data, errors } = await anvilClient.generatePDF(exampleData)
+  if (statusCode !== 200) {
+    console.log('Errors:', JSON.stringify(errors, null, 2))
+    return
+  }
+  fs.writeFileSync('generate-markdown-output.pdf', data, { encoding: null })
+  console.log('Saved generate-markdown-output.pdf')
+}
+
+main()

--- a/examples/generate-markdown.ts
+++ b/examples/generate-markdown.ts
@@ -1,0 +1,39 @@
+// Generate a PDF from Markdown with the Anvil API.
+// https://www.useanvil.com/docs/api/generate-pdf
+//
+// Run: ANVIL_API_KEY=<key> yarn ts-node examples/generate-markdown.ts
+import fs from 'fs'
+import Anvil from '@anvilco/anvil'
+
+const anvilClient = new Anvil({ apiKey: process.env['ANVIL_API_KEY'] ?? '' })
+
+const exampleData = {
+  title: 'Example Invoice',
+  data: [{
+    label: 'Name',
+    content: 'Sally Jones',
+  }, {
+    content: 'Lorem **ipsum** dolor sit _amet_, consectetur adipiscing elit.',
+  }, {
+    table: {
+      firstRowHeaders: true,
+      rows: [
+        ['Description', 'Quantity', 'Price'],
+        ['4x Large Widgets', '4', '$40.00'],
+        ['10x Medium Widgets', '10', '$100.00'],
+      ],
+    },
+  }],
+}
+
+async function main () {
+  const { statusCode, data, errors } = await anvilClient.generatePDF(exampleData)
+  if (statusCode !== 200 || !data) {
+    console.log('Errors:', JSON.stringify(errors, null, 2))
+    return
+  }
+  fs.writeFileSync('generate-markdown-output.pdf', data, { encoding: null })
+  console.log('Saved generate-markdown-output.pdf')
+}
+
+main()


### PR DESCRIPTION
Adds runnable example scripts under `examples/` in the canonical layout the marketing-site SDK pages source from (anvilco/marketing-site#3646):

- `examples/fill.{js,ts}`
- `examples/generate-markdown.{js,ts}`
- `examples/generate-html.{js,ts}`
- `examples/create-etch-packet.{js,ts}`

These migrate the clean, published-package snippets off `anvil-api-usage-examples` and into this repo so the SDK owns its own examples. Each is self-contained and runnable with `ANVIL_API_KEY` set (no shared repo scaffolding).

The existing `example/script/*` dev scripts are left untouched; making the on-page code panel runnable is separate work (#3508).

Draft while the marketing sourcing wiring lands.
